### PR TITLE
9.0-mig-account_invoice_change_currency

### DIFF
--- a/account_invoice_change_currency/README.rst
+++ b/account_invoice_change_currency/README.rst
@@ -6,12 +6,9 @@
 Account Invoice Change Currency
 ===============================
 
-This module replace original odoo wizard for changing currency on an invoice with serveral
-improovements:
-
-* Preview and allow to change the rate thats is going to be used:
-* Log the currency change on the chatter
-* Add this functionality to supplier invoices
+This module adds a wizard for changing currency on invoices.
+It allows you to preview and change the rate thats is going to be used.
+It also logs the currency change on the chatter.
 
 Installation
 ============

--- a/account_invoice_change_currency/README.rst
+++ b/account_invoice_change_currency/README.rst
@@ -1,0 +1,60 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================
+Account Invoice Change Currency
+===============================
+
+This module replace original odoo wizard for changing currency on an invoice with serveral
+improovements:
+
+* Preview and allow to change the rate thats is going to be used:
+* Log the currency change on the chatter
+* Add this functionality to supplier invoices
+
+Installation
+============
+
+To install this module, you need to:
+
+  Just install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+Use multicurrency in invoicing configuration seetings
+
+
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Firstname Lastname <jjs@adhoc.com.ar>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_change_currency/__init__.py
+++ b/account_invoice_change_currency/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in module root
+# directory
+##############################################################################
+from . import wizard
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_change_currency/__openerp__.py
+++ b/account_invoice_change_currency/__openerp__.py
@@ -23,16 +23,6 @@
     'category': 'Accounting & Finance',
     'demo_xml': [],
     'depends': ['account'],
-    'description': '''
-Account Invoice Change Currency
-===============================
-Replace original odoo wizard for changing currency on an invoice with serveral
-improovements:
-
-* Preview and allow to change the rate thats is going to be used:
-* Log the currency change on the chatter
-* Add this functionality to supplier invoices
-''',
     'installable': True,
     'name': 'Account Invoice Change Currency',
     'test': [],

--- a/account_invoice_change_currency/__openerp__.py
+++ b/account_invoice_change_currency/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'author': 'ADHOC SA',
+    'category': 'Accounting & Finance',
+    'demo_xml': [],
+    'depends': ['account'],
+    'description': '''
+Account Invoice Change Currency
+===============================
+Replace original odoo wizard for changing currency on an invoice with serveral
+improovements:
+
+* Preview and allow to change the rate thats is going to be used:
+* Log the currency change on the chatter
+* Add this functionality to supplier invoices
+''',
+    'installable': True,
+    'name': 'Account Invoice Change Currency',
+    'test': [],
+    'data': [
+        'views/invoice_view.xml',
+        'wizard/account_change_currency_view.xml',
+    ],
+    'version': '9.0.1.0.0',
+    'website': 'www.adhoc.com.ar',
+    'license': 'AGPL-3'}
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_change_currency/__openerp__.py
+++ b/account_invoice_change_currency/__openerp__.py
@@ -27,8 +27,8 @@
     'name': 'Account Invoice Change Currency',
     'test': [],
     'data': [
-        'views/invoice_view.xml',
         'wizard/account_change_currency_view.xml',
+        'views/invoice_view.xml',
     ],
     'version': '9.0.1.0.0',
     'website': 'www.adhoc.com.ar',

--- a/account_invoice_change_currency/i18n/es.po
+++ b/account_invoice_change_currency/i18n/es.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_invoice_change_currency
+# 
+# Translators:
+# emiq2 <eq@ingadhoc.com>, 2016
+# Juan José Scarafía <scarafia.juanjose@gmail.com>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: account-invoicing (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-24 22:59+0000\n"
+"PO-Revision-Date: 2016-05-24 22:19+0000\n"
+"Last-Translator: Juan José Scarafía <scarafia.juanjose@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/adhoc/ingadhoc-account-invoicing-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_invoice_change_currency
+#: view:account.invoice:account_invoice_change_currency.invoice_supplier_form
+msgid "(change)"
+msgstr "(Cambiar)"
+
+#. module: account_invoice_change_currency
+#: model:ir.model,name:account_invoice_change_currency.model_account_change_currency
+msgid "Change Currency"
+msgstr "Cambiar Moneda"
+
+#. module: account_invoice_change_currency
+#: field:account.change.currency,currency_rate:0
+msgid "Currency Rate"
+msgstr "Tasa de Cambio"
+
+#. module: account_invoice_change_currency
+#: code:addons/account_invoice_change_currency/wizard/account_change_currency.py:21
+#, python-format
+msgid "No Invoice on context as \"active_id\""
+msgstr "Ninguna factura en el contexto como \"active_id\""
+
+#. module: account_invoice_change_currency
+#: code:addons/account_invoice_change_currency/wizard/account_change_currency.py:31
+#, python-format
+msgid "Old Currency And New Currency can not be the same"
+msgstr "La moneda anterior y la nueva no pueden ser la misma"
+
+#. module: account_invoice_change_currency
+#: help:account.change.currency,currency_rate:0
+msgid "Select a currency to apply on the invoice"
+msgstr "Seleccione una moneda para aplicar en la Factura"

--- a/account_invoice_change_currency/views/invoice_view.xml
+++ b/account_invoice_change_currency/views/invoice_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="invoice_supplier_form">
+            <field name="name">account.invoice_supplier.view</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="model">account.invoice</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="after">
+                    <label attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user" string=""/>
+                    <button name="%(action_account_change_currency)d" type="action" class="oe_inline oe_link oe_edit_only" string="(change)" attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="invoice_form">
+            <field name="name">account.invoice_supplier.view</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="model">account.invoice</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="after">
+                    <label attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user" string=""/>
+                    <button name="%(action_account_change_currency)d" type="action" class="oe_inline oe_link oe_edit_only" string="(change)" attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_invoice_change_currency/views/invoice_view.xml
+++ b/account_invoice_change_currency/views/invoice_view.xml
@@ -2,6 +2,18 @@
 <openerp>
     <data>
 
+        <record model="ir.ui.view" id="invoice_form">
+            <field name="name">account.invoice_supplier.view</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="model">account.invoice</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="after">
+                    <label attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user" string=""/>
+                    <button name="%(action_account_change_currency)d" type="action" class="oe_inline oe_link oe_edit_only" string="(change)" attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user"/>
+                </field>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="invoice_supplier_form">
             <field name="name">account.invoice_supplier.view</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
@@ -14,17 +26,6 @@
             </field>
         </record>
 
-        <record model="ir.ui.view" id="invoice_form">
-            <field name="name">account.invoice_supplier.view</field>
-            <field name="inherit_id" ref="account.invoice_form"/>
-            <field name="model">account.invoice</field>
-            <field name="arch" type="xml">
-                <field name="currency_id" position="after">
-                    <label attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user" string=""/>
-                    <button name="%(action_account_change_currency)d" type="action" class="oe_inline oe_link oe_edit_only" string="(change)" attrs="{'invisible':[('state','!=','draft')]}" groups="account.group_account_user"/>
-                </field>
-            </field>
-        </record>
 
     </data>
 </openerp>

--- a/account_invoice_change_currency/wizard/__init__.py
+++ b/account_invoice_change_currency/wizard/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in module root
+# directory
+##############################################################################
+from . import account_change_currency
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_change_currency/wizard/account_change_currency.py
+++ b/account_invoice_change_currency/wizard/account_change_currency.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+from openerp import fields, models, api, _
+from openerp.exceptions import Warning
+
+
+class account_change_currency(models.TransientModel):
+    _name = 'account.change.currency'
+    _description = 'Change Currency'
+
+    currency_id = fields.Many2one('res.currency', string='Change to', required=True, help="Select a currency to apply on the invoice")
+    currency_rate = fields.Float(
+        'Currency Rate',
+        required=True,
+        help="Select a currency to apply on the invoice"
+        )
+
+    @api.multi
+    def get_invoice(self):
+        self.ensure_one()
+        invoice = self.env['account.invoice'].browse(
+            self._context.get('active_id', False))
+        if not invoice:
+            raise Warning(_('No Invoice on context as "active_id"'))
+        return invoice
+
+    @api.onchange('currency_id')
+    def onchange_currency(self):
+        invoice = self.get_invoice()
+        if not self.currency_id:
+            self.currency_rate = False
+        else:
+            if self.currency_id == invoice.currency_id:
+                raise Warning(_(
+                    'Old Currency And New Currency can not be the same'))
+            currency = invoice.currency_id.with_context(
+                date=invoice.date_invoice or fields.Date.context_today(self))
+            self.currency_rate = currency.compute(
+                1.0, self.currency_id)
+
+    @api.multi
+    def change_currency(self, ):
+        """
+        We overwrite original function to simplify and add functionality
+        descrived on the manifest
+        """
+        self.ensure_one()
+        invoice = self.get_invoice()
+        for line in invoice.invoice_line_ids:
+            line.price_unit = self.currency_id.round(
+                    line.price_unit * self.currency_rate)
+        invoice.currency_id = self.currency_id.id
+        return {'type': 'ir.actions.act_window_close'}
+
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_invoice_change_currency/wizard/account_change_currency_view.xml
+++ b/account_invoice_change_currency/wizard/account_change_currency_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_account_change_currency" model="ir.ui.view">
+            <field name="name">Change Currency</field>
+            <field name="model">account.change.currency</field>
+            <!--<field name="inherit_id" ref="account.view_account_change_currency"/>-->
+            <field name="arch" type="xml">
+                <form string="Invoice Currency">
+                    <group string="This wizard will change the currency of the invoice">
+                        <field name="currency_id"/>
+                        <field name="currency_rate"/>
+                    </group>
+                    <footer>
+                        <button name="change_currency" string="Change Currency" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_account_change_currency" model="ir.actions.act_window">
+            <field name="name">Change Currency</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">account.change.currency</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_account_change_currency"/>
+            <field name="context">{}</field>
+            <field name="target">new</field>
+        </record>
+    </data>
+</openerp>

--- a/account_invoice_commercial/account_invoice.py
+++ b/account_invoice_commercial/account_invoice.py
@@ -24,7 +24,7 @@ class account_invoice(models.Model):
 
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
-        ret = super(account_invoice, self).onchange_partner_id()
+        ret = super(account_invoice, self)._onchange_partner_id()
         if self.partner_id and self.partner_id.user_id:
             self.user_id = self.partner_id.user_id.id
         else:


### PR DESCRIPTION
migrar a v9.0 para forzar que el asiento generado en una factura guarde
los datos en otra moneda
