### PR TITLE
[FIX] account_invoice_move_currency: Set api.one

### DIFF
--- a/account_invoice_move_currency/models/account_invoice.py
+++ b/account_invoice_move_currency/models/account_invoice.py
@@ -26,6 +26,7 @@ class AccountInvoice(models.Model):
         states={'draft': [('readonly', False)]},
     )
 
+    @api.one
     @api.depends('move_currency_id')
     def _compute_residual(self):
         """

--- a/account_invoice_prices_update/wizards/account_invoice_prices_update_wizard.py
+++ b/account_invoice_prices_update/wizards/account_invoice_prices_update_wizard.py
@@ -7,6 +7,7 @@ from odoo import models, fields, api
 
 class AccountInvoicePricesUpdateWizard(models.TransientModel):
     _name = 'account.invoice.prices_update.wizard'
+    _description = 'account.invoice.prices_update.wizard'
 
     pricelist_id = fields.Many2one(
         'product.pricelist',


### PR DESCRIPTION
The original method having the api.one and we call from a super we need to add them in the inherit method