### PR TITLE
[FIX] account_invoice_move_currency: mig script

### DIFF
--- a/account_invoice_move_currency/migrations/13.0.1.2.0/post-migration.py
+++ b/account_invoice_move_currency/migrations/13.0.1.2.0/post-migration.py
@@ -10,7 +10,7 @@ def migrate(env, version):
          ('currency_id', '=', False)]):
         amount = line.debit if line.debit else line.credit
         sign = 1.0 if line.debit else -1.0
-        line.write({
+        line._write({
             'currency_id': line.move_id.move_currency_id.id,
             'amount_currency': sign * line.move_id.move_currency_id.round(
                 amount / line.move_id.move_inverse_currency_rate)})


### PR DESCRIPTION
use _write to avoid already reconcile constraint