### PR TITLE
[IMP] account_invoice_tax: no need for odoo patch

### DIFF
--- a/account_invoice_tax/README.rst
+++ b/account_invoice_tax/README.rst
@@ -14,8 +14,7 @@
 Account Invoice Tax
 ===================
 
-Add new buttons in the Vendor Bills that let us to add/remove taxes to all the lines
-of a vendor bill.
+Add new buttons in the Vendor Bills that let us to add/remove taxes to all the lines of a vendor bill.
 
 
 Installation

--- a/account_invoice_tax/__manifest__.py
+++ b/account_invoice_tax/__manifest__.py
@@ -5,6 +5,7 @@
     'category': 'Localization',
     'depends': [
         'account',
+        'account_ux',  # for _recompute_tax_lines patch
     ],
     'data': [
         'wizards/account_invoice_tax_view.xml',


### PR DESCRIPTION
Before this commit this patch was needed on odoo server https://github.com/odoo/odoo/pull/67632/files
But odoo has change those methods and the patch no longer works.
We improve it by adding functionality on account_ux


Together with https://github.com/ingadhoc/account-financial-tools/pull/306