### PR TITLE
[FIX] account_invoice_move_currency; journal entries to draft

### DIFF
--- a/account_invoice_move_currency/models/account_move.py
+++ b/account_invoice_move_currency/models/account_move.py
@@ -87,8 +87,12 @@ class AccountMove(models.Model):
         return res
 
     def button_draft(self):
-        self.line_ids.write({
-        'currency_id': False,
-        'amount_currency': 0.0,
-        })
+        """ In order to be able to return a secondary currency invoice to draft and avoid Odoo to recompute the move
+        totals amounts using the wrong currency (the secondary currency, we use the next two fields only as a hack so
+        we need to clean them to avoid Odoo compute the invoice amounts wrongly) """
+        if self.is_invoice():
+            self.line_ids.write({
+                'currency_id': False,
+                'amount_currency': 0.0,
+            })
         return super().button_draft()


### PR DESCRIPTION
ticket 49049
---

Before this change, the user was not able to set a journal entry to draft. This was because we introduce this error solving a secondary currency problem in invoices in this commit https://github.com/ingadhoc/account-invoicing/commit/087bfad77538d5b7db4802a3ca9cf82c582fa401 that was actually a fix for another problem.