### PR TITLE
[FIX] account_invoice_line_number: compute lines

### DIFF
--- a/account_invoice_line_number/__manifest__.py
+++ b/account_invoice_line_number/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Invoice Line Number',
-    'version': "13.0.1.1.0",
+    'version': "13.0.1.2.0",
     'category': 'Accounting & Finance',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/account_invoice_line_number/models/__init__.py
+++ b/account_invoice_line_number/models/__init__.py
@@ -3,3 +3,4 @@
 # directory
 ##############################################################################
 from . import account_move_line
+from . import account_move

--- a/account_invoice_line_number/models/account_move.py
+++ b/account_invoice_line_number/models/account_move.py
@@ -1,0 +1,21 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    number_lines = fields.Char(compute='_compute_number_lines')
+
+    def _compute_number_lines(self):
+        self.number_lines = False
+        if self and not isinstance(self[0].id, int):
+            return
+        for move in self:
+            number_line_map = {}
+            for number, line in enumerate(move.invoice_line_ids.sorted("sequence"), 1):
+                number_line_map.update({line.id: number})
+
+            move.number_lines = number_line_map

--- a/account_invoice_line_number/models/account_move_line.py
+++ b/account_invoice_line_number/models/account_move_line.py
@@ -19,8 +19,6 @@ class AccountMoveLine(models.Model):
         self.number = False
         if self and not isinstance(self[0].id, int):
             return
-        for move in self.mapped('move_id'):
-            number = 1
-            for line in move.invoice_line_ids.sorted("sequence"):
-                line.number = number
-                number += 1
+        mapping = eval(self[0].move_id.number_lines)
+        for line in self:
+            line.number = mapping.get(line.id)

--- a/account_invoice_line_number/views/account_move_view.xml
+++ b/account_invoice_line_number/views/account_move_view.xml
@@ -8,6 +8,9 @@
             <field name="sequence" position="after">
                 <field name="number" string="nbr" optional="show"/>
             </field>
+            <form position="inside">
+                <field name="number_lines" invisible="1"/>
+            </form>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Now the line numbers are computed correctly
when displaying the invoice