### PR TITLE
[FIX] account_invoice_tax: avoid including amount_currency when not needed

### DIFF
--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -130,12 +130,16 @@ class AccountInvoiceTaxLine(models.TransientModel):
         company_currency = self.invoice_tax_id.move_id.company_currency_id
         not_company_currency = move_currency and move_currency != company_currency
 
-        return {
-            "amount_currency": self.amount if not_company_currency else None,
+        values = {
             "debit": debit_cc if not_company_currency else debit,
             "credit": credit_cc if not_company_currency else credit,
             "balance": (self.amount_company_currency if not_company_currency else self.amount) * (1 if debit else -1),
         }
+
+        if not_company_currency and self.amount:
+            values["amount_currency"] = self.amount
+
+        return values
 
     def _compute_amount_company_currency(self):
         for line in self:


### PR DESCRIPTION

Fixed an issue in '_get_amount_updated_values' where 'amount_currency' was included in the dictionary even when unnecessary, causing errors when 'amount_company_currency' was set to 'None'.

Now, 'amount_currency' is only added if the move's currency differs from the company currency and 'self.amount' is set. This prevents operations involving 'None' values, avoiding errors when processing the data.

Reported error:
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'