### PR TITLE
[FIX] account_invoice_commisson: Hide commission_amount column when not in commission context

### DIFF
--- a/account_invoice_commission/__manifest__.py
+++ b/account_invoice_commission/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Commission Invoices",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_invoice_commission/views/account_move_view.xml
+++ b/account_invoice_commission/views/account_move_view.xml
@@ -19,7 +19,7 @@
                 </page>
             </notebook>
             <xpath expr="//field[@name='invoice_line_ids']/list" position="inside">
-                <field name="commission_amount" invisible="not context.get('commissioned_partner_id', False)" sum="Total" optional="hide"/>
+                <field name="commission_amount" column_invisible="not context.get('commissioned_partner_id', False)" sum="Total" optional="hide"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION

Added the 'column_invisible' attribute to the commission_amount field in the invoice_line_ids list view.

This ensures that the entire column is hidden when the context does not include 'commissioned_partner_id'. Previously, only the cell values were hidden but the column header remained visible.