### PR TITLE
[IMP] account_invoice_tax: better ux + protect analytic taxes

### DIFF
--- a/account_invoice_tax/__manifest__.py
+++ b/account_invoice_tax/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Invoice Tax",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.0.0",
     "author": "ADHOC SA",
     "category": "Localization",
     "depends": [

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -8,7 +8,6 @@ class AccountInvoiceTax(models.TransientModel):
     _description = "Account Invoice Tax"
 
     move_id = fields.Many2one("account.move", required=True)
-    company_id = fields.Many2one(related="move_id.company_id")
     tax_line_ids = fields.One2many("account.invoice.tax_line", "invoice_tax_id")
 
     @api.model
@@ -110,11 +109,25 @@ class AccountInvoiceTax(models.TransientModel):
 class AccountInvoiceTaxLine(models.TransientModel):
     _name = "account.invoice.tax_line"
     _description = "Account Invoice Tax line"
+    _check_company_auto = True
+    _check_company_domain = models.check_companies_domain_parent_of
 
     invoice_tax_id = fields.Many2one("account.invoice.tax")
-    tax_id = fields.Many2one("account.tax", required=True)
+    tax_id = fields.Many2one(
+        "account.tax",
+        required=True,
+        check_company=True,
+        domain="[('type_tax_use', '=', 'purchase'), ('id', 'not in', existing_tax_ids)]",
+    )
+    company_id = fields.Many2one(related="invoice_tax_id.move_id.company_id")
     currency_id = fields.Many2one(related="invoice_tax_id.move_id.currency_id")
+    existing_tax_ids = fields.Many2many("account.tax", compute="_compute_existing_taxes")
     amount = fields.Monetary(
         currency_field="currency_id",
     )
     new_tax = fields.Boolean(default=True)
+
+    @api.depends("invoice_tax_id.tax_line_ids.tax_id")
+    def _compute_existing_taxes(self):
+        for record in self:
+            record.existing_tax_ids = record.invoice_tax_id.tax_line_ids.mapped("tax_id")

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountInvoiceTax(models.TransientModel):
@@ -19,10 +20,14 @@ class AccountInvoiceTax(models.TransientModel):
             else self.env["account.move"]
         )
         res["move_id"] = move_ids[0].id if move_ids else False
+        if move_ids[0].move_type == "in_invoice":
+            sign = 1
+        else:  # For refund
+            sign = -1
         lines = []
         for line in move_ids[0].line_ids.filtered(lambda x: x.tax_line_id):
             lines.append(
-                Command.create({"tax_id": line.tax_line_id.id, "amount": line.amount_currency, "new_tax": False})
+                Command.create({"tax_id": line.tax_line_id.id, "amount": line.amount_currency * sign, "new_tax": False})
             )
         res["tax_line_ids"] = lines
 
@@ -91,6 +96,16 @@ class AccountInvoiceTax(models.TransientModel):
             "context": self._context,
         }
 
+    @api.constrains("tax_line_ids")
+    @api.onchange("tax_line_ids")
+    def check_analytic(self):
+        taxes = self.tax_line_ids.filtered("tax_id.analytic").mapped("tax_id")
+        if taxes:
+            raise UserError(
+                'No puede usar este asistente ya que algún impuesto tiene establecido "Incluir en el costo analítico?".\nImpuestos: %s'
+                % (", ".join(taxes.mapped(lambda x: "%s (%s)" % (x.name, x.id))))
+            )
+
 
 class AccountInvoiceTaxLine(models.TransientModel):
     _name = "account.invoice.tax_line"
@@ -98,5 +113,8 @@ class AccountInvoiceTaxLine(models.TransientModel):
 
     invoice_tax_id = fields.Many2one("account.invoice.tax")
     tax_id = fields.Many2one("account.tax", required=True)
-    amount = fields.Float()
+    currency_id = fields.Many2one(related="invoice_tax_id.move_id.currency_id")
+    amount = fields.Monetary(
+        currency_field="currency_id",
+    )
     new_tax = fields.Boolean(default=True)

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -110,8 +110,6 @@ class AccountInvoiceTaxLine(models.TransientModel):
 
     def _get_amount_updated_values(self):
         debit = credit = debit_cc = credit_cc = 0
-        if self.amount and not self.amount_company_currency:
-            self._compute_amount_company_currency()
         if self.invoice_tax_id.move_id.move_type == "in_invoice":
             if self.amount > 0:
                 debit = self.amount

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -10,8 +10,6 @@ class AccountInvoiceTax(models.TransientModel):
     company_id = fields.Many2one(related="move_id.company_id")
     tax_line_ids = fields.One2many("account.invoice.tax_line", "invoice_tax_id")
 
-    is_in_company_currency = fields.Boolean(compute="_compute_is_in_company_currency")
-
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
@@ -88,10 +86,6 @@ class AccountInvoiceTax(models.TransientModel):
             "context": self._context,
         }
 
-    @api.depends("move_id")
-    def _compute_is_in_company_currency(self):
-        self.is_in_company_currency = self.move_id.currency_id == self.move_id.company_currency_id
-
 
 class AccountInvoiceTaxLine(models.TransientModel):
     _name = "account.invoice.tax_line"
@@ -100,51 +94,25 @@ class AccountInvoiceTaxLine(models.TransientModel):
     invoice_tax_id = fields.Many2one("account.invoice.tax")
     tax_id = fields.Many2one("account.tax", required=True)
     amount = fields.Float()
-    amount_company_currency = fields.Float(
-        compute="_compute_amount_company_currency",
-        readonly=False,
-        store=True,
-    )
-
     new_tax = fields.Boolean(default=True)
 
     def _get_amount_updated_values(self):
-        debit = credit = debit_cc = credit_cc = 0
+        debit = credit = 0
         if self.invoice_tax_id.move_id.move_type == "in_invoice":
             if self.amount > 0:
                 debit = self.amount
-                debit_cc = self.amount_company_currency
             elif self.amount < 0:
                 credit = -self.amount
-                credit_cc = -self.amount_company_currency
         else:  # For refund
             if self.amount > 0:
                 credit = self.amount
-                credit_cc = self.amount_company_currency
             elif self.amount < 0:
                 debit = -self.amount
-                debit_cc = -self.amount_company_currency
 
         # If multi currency enable
         move_currency = self.invoice_tax_id.move_id.currency_id
         company_currency = self.invoice_tax_id.move_id.company_currency_id
-        not_company_currency = move_currency and move_currency != company_currency
+        if move_currency and move_currency != company_currency:
+            return {"amount_currency": self.amount if debit else -self.amount}
 
-        values = {
-            "debit": debit_cc if not_company_currency else debit,
-            "credit": credit_cc if not_company_currency else credit,
-            "balance": (self.amount_company_currency if not_company_currency else self.amount) * (1 if debit else -1),
-        }
-
-        if not_company_currency and self.amount:
-            values["amount_currency"] = self.amount
-
-        return values
-
-    def _compute_amount_company_currency(self):
-        for line in self:
-            taxes = line.invoice_tax_id.move_id.tax_totals["subtotals"][0]["tax_groups"]
-            for tax_group in taxes:
-                if line.tax_id.id == tax_group["involved_tax_ids"][0]:
-                    line.amount_company_currency = tax_group["tax_amount"]
-                    break
+        return {"debit": debit, "credit": credit, "balance": self.amount if debit else -self.amount}

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -61,6 +61,11 @@ class AccountInvoiceTax(models.TransientModel):
 
         # set amount in the new created tax line. En este momento si queda balanceado y se ajusta la linea AP/AR
         container = {"records": move}
+
+        if move.move_type == "in_invoice":
+            sign = 1
+        else:  # For refund
+            sign = -1
         with move._check_balanced(container):
             with move._sync_dynamic_lines(container):
                 # restauramos todos los valores de impuestos fixed que se habrian recomputado
@@ -73,7 +78,7 @@ class AccountInvoiceTax(models.TransientModel):
                 for tax_line_id in self.tax_line_ids:
                     # seteamos valor al impuesto segun lo que puso en el wizard
                     line_with_tax = move.line_ids.filtered(lambda x: x.tax_line_id == tax_line_id.tax_id)
-                    line_with_tax.write(tax_line_id._get_amount_updated_values())
+                    line_with_tax.write({"amount_currency": tax_line_id.amount * sign})
 
     def add_tax_and_new(self):
         self.add_tax()
@@ -95,24 +100,3 @@ class AccountInvoiceTaxLine(models.TransientModel):
     tax_id = fields.Many2one("account.tax", required=True)
     amount = fields.Float()
     new_tax = fields.Boolean(default=True)
-
-    def _get_amount_updated_values(self):
-        debit = credit = 0
-        if self.invoice_tax_id.move_id.move_type == "in_invoice":
-            if self.amount > 0:
-                debit = self.amount
-            elif self.amount < 0:
-                credit = -self.amount
-        else:  # For refund
-            if self.amount > 0:
-                credit = self.amount
-            elif self.amount < 0:
-                debit = -self.amount
-
-        # If multi currency enable
-        move_currency = self.invoice_tax_id.move_id.currency_id
-        company_currency = self.invoice_tax_id.move_id.company_currency_id
-        if move_currency and move_currency != company_currency:
-            return {"amount_currency": self.amount if debit else -self.amount}
-
-        return {"debit": debit, "credit": credit, "balance": self.amount if debit else -self.amount}

--- a/account_invoice_tax/wizards/account_invoice_tax_view.xml
+++ b/account_invoice_tax/wizards/account_invoice_tax_view.xml
@@ -11,7 +11,6 @@
                     <field colspan="2" nolabel="1" name="tax_line_ids">
                         <list decoration-info="new_tax == True" editable="bottom">
                             <field name="tax_id" domain="[('type_tax_use', '=', 'purchase'), ('company_id', '=', parent.company_id)]" options="{'no_create': True, 'no_edit': True}"/>
-                            <field name="amount_company_currency" column_invisible="parent.is_in_company_currency"/>
                             <field name="amount"/>
                             <field name="new_tax" column_invisible="True"/>
                         </list>

--- a/account_invoice_tax/wizards/account_invoice_tax_view.xml
+++ b/account_invoice_tax/wizards/account_invoice_tax_view.xml
@@ -6,14 +6,15 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="company_id" invisible="1"/>
                     <field name="move_id" invisible="1"/>
                     <field colspan="2" nolabel="1" name="tax_line_ids">
                         <list decoration-info="new_tax == True" editable="bottom">
-                            <field name="tax_id" domain="[('type_tax_use', '=', 'purchase'), ('company_id', '=', parent.company_id)]" options="{'no_create': True, 'no_edit': True}"/>
+                            <field name="tax_id" options="{'no_create': True, 'no_edit': True}"/>
                             <field name="amount"/>
+                            <field name="company_id" column_invisible="True"/>
                             <field name="currency_id" column_invisible="True"/>
                             <field name="new_tax" column_invisible="True"/>
+                            <field name="existing_tax_ids" column_invisible="True"/>
                         </list>
                     </field>
                 </group>

--- a/account_invoice_tax/wizards/account_invoice_tax_view.xml
+++ b/account_invoice_tax/wizards/account_invoice_tax_view.xml
@@ -12,6 +12,7 @@
                         <list decoration-info="new_tax == True" editable="bottom">
                             <field name="tax_id" domain="[('type_tax_use', '=', 'purchase'), ('company_id', '=', parent.company_id)]" options="{'no_create': True, 'no_edit': True}"/>
                             <field name="amount"/>
+                            <field name="currency_id" column_invisible="True"/>
                             <field name="new_tax" column_invisible="True"/>
                         </list>
                     </field>


### PR DESCRIPTION
1. Mostramos símbolo de la moneda (usamos field monetary)
2. Mejoramos para que en notas de crédito se vea importe positivo si impuesto es postivo
3. Agregamos protección para que no se usen impuestos con setup de analitico porque no está bien implementado y, según analizamos:
* tiene poco uso: solo primicia, gestionen, linos y londero
* no tiene tanto sentido contable
* es complejo de resolver, habŕia que ver si seguimos mostrando representación de cada apunte (ya multiplicado) pero tenemos que mejorar que apunte terminamos actualizando al guardar. tmb que hacer al agregar nuevo línea de impuesto porque esta deberia multiplicarse en la cantida  de apuntes analiticos correspondientes