### PR TITLE
[ADD] account_invoice_commission: Add account filter to commission rules

### DIFF
--- a/account_invoice_commission/__manifest__.py
+++ b/account_invoice_commission/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Commission Invoices",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_invoice_commission/models/account_commission_rule.py
+++ b/account_invoice_commission/models/account_commission_rule.py
@@ -55,8 +55,20 @@ class AccountCommissionRule(models.Model):
         default=0.0,
     )
     percent_commission = fields.Float("Percentage Commission")
+    account_id = fields.Many2one(
+        "account.account",
+        "Commission Account",
+        domain="[('company_ids', '=', company_id)]",
+        help="Account to be used for commission entries. "
+        "If not set, the default commission account will be used.",
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        "Company",
+        default=lambda self: self.env.company,
+    )
 
-    def _get_rule_domain(self, date, product, partner_id, customer, amount):
+    def _get_rule_domain(self, date, product, partner_id, customer, amount, account_id=False):
         domain = [
             "|",
             ("date_start", "=", False),
@@ -70,6 +82,8 @@ class AccountCommissionRule(models.Model):
             ("partner_id", "in", [False, partner_id]),
             ("customer_id", "in", [False, customer.id]),
         ]
+        if account_id:
+            domain += [("account_id", "in", [False, account_id])]
         # para lineas sin producto buscamos solamente las de false
         if not product:
             domain += [("product_tmpl_id", "=", False), ("categ_id", "=", False)]
@@ -82,6 +96,6 @@ class AccountCommissionRule(models.Model):
             ]
         return domain
 
-    def _get_rule(self, date, product, partner_id, customer, amount):
-        domain = self._get_rule_domain(date, product, partner_id, customer, amount)
+    def _get_rule(self, date, product, partner_id, customer, amount, account_id=False):
+        domain = self._get_rule_domain(date, product, partner_id, customer, amount, account_id)
         return self.search(domain, limit=1)

--- a/account_invoice_commission/models/account_move_line.py
+++ b/account_invoice_commission/models/account_move_line.py
@@ -31,6 +31,7 @@ class AccountMoveLine(models.Model):
                     commissioned_partner_id,
                     rec.move_id.commercial_partner_id,
                     -rec.balance,
+                    rec.account_id.id,
                 )
                 if rule:
                     rec.commission_amount = rule.percent_commission * -rec.balance / 100.0

--- a/account_invoice_commission/views/account_commission_rule_view.xml
+++ b/account_invoice_commission/views/account_commission_rule_view.xml
@@ -14,6 +14,8 @@
                 <field name="categ_id"/>
                 <field name="min_amount"/>
                 <field name="percent_commission"/>
+                <field name="account_id" optional="show"/>
+                <field name="company_id" column_invisible="1"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Previously, commission rules were filtered by advance products. This commit changes the approach to use account-based filtering instead.

Changes:
- Add account_id field to account.commission.rule model
- Add company_id field for proper domain filtering
- Update commission rule views to display the new account field
- Modify _get_rule_domain and _get_rule methods to filter by account_id
- Update commission calculation in account.move.line to pass account_id

This allows more flexible commission rules based on the account used in invoice lines rather than relying on specific advance products.