### PR TITLE
[ADD] account_invoice_move_currency: exchange rate on customer invoices

### DIFF
--- a/account_invoice_move_currency/README.rst
+++ b/account_invoice_move_currency/README.rst
@@ -1,0 +1,92 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==============================
+Account Invoice Move Currency
+==============================
+
+This module adds an editable field for the user to report the exchange rate on customer invoices.
+
+The module provides:
+
+* A secondary currency field for informative purposes on invoices
+* An informative exchange rate field that displays the rate between the secondary currency and the company currency
+* These fields are automatically calculated but can be edited when the invoice is in draft state
+
+The informative exchange rate helps users understand currency conversions at the time of the invoice without affecting the accounting entries.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install the module dependencies
+#. Install this module from Apps menu
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. No specific configuration needed
+#. Make sure you have the proper exchange rates configured in your system
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to Accounting > Customers > Invoices (or Vendor Bills)
+#. Create or edit an invoice/bill in draft state
+#. When the invoice currency is different from the company currency, you will see:
+
+   * **Rate Currency**: Select a secondary currency for reference
+   * **Informative Exchange Rate**: Shows the exchange rate (automatically calculated, but editable in draft)
+
+#. The fields are visible only when:
+
+   * The invoice currency differs from the company currency
+   * The move type is invoice or refund (customer/vendor)
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* ADHOC SA: `Icon <https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png>`__.
+
+Contributors
+------------
+
+Maintainer
+----------
+
+.. image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+This module is maintained by the ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/account_invoice_move_currency/__init__.py
+++ b/account_invoice_move_currency/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import models

--- a/account_invoice_move_currency/__manifest__.py
+++ b/account_invoice_move_currency/__manifest__.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Account Invoice Move Currency",
+    "version": "18.0.1.0.0",
+    "category": "Technical",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Adds an editable field for the user to report the exchange rate on customer invoices.",
+    "depends": [
+        "account_ux",
+    ],
+    "data": [
+        "views/account_move_view.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/account_invoice_move_currency/models/__init__.py
+++ b/account_invoice_move_currency/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/account_invoice_move_currency/models/account_move.py
+++ b/account_invoice_move_currency/models/account_move.py
@@ -1,0 +1,36 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    user_exchange_rate = fields.Float(
+        string="Informative Exchange Rate",
+        help="Informative exchange rate value.",
+        digits=(16, 2),
+        compute="_compute_user_exchange_rate",
+        store=True,
+    )
+
+    user_secondary_currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Secondary Currency",
+    )
+
+    @api.depends("user_secondary_currency_id", "invoice_date", "company_id")
+    def _compute_user_exchange_rate(self):
+        for move in self:
+            move.user_exchange_rate = False
+            currency = move.user_secondary_currency_id
+            date = move.invoice_date
+
+            if currency and date:
+                rates_dict = currency._get_rates(move.company_id, date)
+                rate = rates_dict.get(currency.id)
+                if rate and rate != 0:
+                    move.user_exchange_rate = 1 / rate

--- a/account_invoice_move_currency/views/account_move_view.xml
+++ b/account_invoice_move_currency/views/account_move_view.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <record id="view_move_form_inherit_user_exchange_rate" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.user.exchange.rate</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <div name="journal_div" position="after">
+                <div class="d-flex align-items-center" invisible="currency_id != company_currency_id or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')">
+                    <label for="user_secondary_currency_id" string="Rate Currency" class="oe_inline"/>
+                    <span class="mx-2"></span>
+                    <field name="user_secondary_currency_id" options="{'no_create': True, 'no_open': True}" class="oe_inline" widget="selection" readonly="state != 'draft'" domain="[('id', '!=', company_currency_id)]"/>
+                    <span class="mx-2" invisible="not user_secondary_currency_id">=</span>
+                    <field name="user_exchange_rate" class="oe_inline" widget="float" invisible="not user_secondary_currency_id" readonly="state != 'draft'" required="user_secondary_currency_id"/>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit adds a new module 'account_invoice_move_currency' that allows users to specify a custom exchange rate on customer invoices. The module introduces two new fields on the account.move model: 'user_secondary_currency_id' for selecting a secondary currency, and 'user_exchange_rate' for entering the exchange rate. The exchange rate field is automatically computed based on the selected secondary currency and the invoice date, but remains editable for user input.