### PR TITLE
[FIX] account_background_post: avoid name collision on validate_move method

### DIFF
--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -59,3 +59,9 @@ class ValidateAccountMove(models.TransientModel):
             return {"type": "ir.actions.act_window_close"}
         else:
             return super().validate_move()
+
+    def validate_move_confirm(self):
+        """Bridge method called from the view's Confirm button renamed to
+        avoid name collision. It delegates to `validate_move` to keep the
+        same behaviour."""
+        return self.validate_move()

--- a/account_background_post/wizards/validate_account_move_views.xml
+++ b/account_background_post/wizards/validate_account_move_views.xml
@@ -19,7 +19,7 @@
                 <button name="validate_move" position="before">
                     <button string="Post in Background" name="action_background_post" type="object" default_focus="1" class="btn-primary" data-hotkey="a" help="With this, all the invoices selected to be validated will be marked and they will be validated one by one. If an error is found when validating any invoice, the automatic validation of the same will be unmarked and it will be notified via messaging"
                     invisible="abnormal_amount_partner_ids"/>
-                    <button string="Confirm" name="validate_move" type="object"
+                    <button string="Confirm now" name="validate_move_confirm" type="object"
                     default_focus="1" class="btn-primary" data-hotkey="q" context="{'validate_analytic': True}"
                     confirm="Only use this option to post a small batch of invoices" invisible="force_background"
                     />


### PR DESCRIPTION
Rename the inserted Confirm button to validate_move_confirm and add a bridge method validate_move_confirm() that delegates to validate_move(). This removes the name="validate_move" collision so the background-post button cannot accidentally trigger the synchronous validate path.