### PR TITLE
[FIX] account_background_post: commit after posting a message on error

### DIFF
--- a/account_background_post/models/account_move.py
+++ b/account_background_post/models/account_move.py
@@ -36,6 +36,7 @@ class AccountMove(models.Model):
                     body=_('We tried to validate this invoice on the background but got this error') + ': \n\n' + plaintext2html(str(exp), 'em'),
                     partner_ids=move.get_internal_partners().ids,
                     body_is_html=True)
+                self.env.cr.commit()
         if len(moves) > batch_size:
             self.env.ref('account_background_post.ir_cron_background_post_invoices')._trigger()
 


### PR DESCRIPTION
When validating an invoice on the background, if an error occurs, a message is posted. However, since the transaction is not committed yet, the message is sent with a delay and only after the transaction is committed. This can be problematic if the error is due to a validation error, as the transaction will be rolled back and the message will never be sent.