### PR TITLE
[IMP] account_invoice_tax: apply percentage tax overrides from wizard…

### DIFF
--- a/account_invoice_tax/models/account_move.py
+++ b/account_invoice_tax/models/account_move.py
@@ -105,13 +105,19 @@ class AccountMove(models.Model):
         for move in container.get("records", self):
             move._apply_tax_overrides()
 
-    def _apply_tax_overrides(self):
+    def _apply_tax_overrides(self, other_taxes_override=False):
         """Re-write values from ``tax_override_data`` onto the matching tax lines.
 
         Only overrides for fixed-amount taxes are applied; percentage-based
-        taxes must always reflect their recomputed values.
+        taxes are always recomputed unless they are present in the
+        ``other_taxes_override`` dictionary.
         """
         overrides = self.tax_override_data or {}
+        if other_taxes_override:
+            # Percentage-based tax overrides are not stored in ``tax_override_data``
+            # as they don't need to survive recomputations, but we still want to
+            # apply them on the current tax lines.
+            overrides.update(other_taxes_override)
         if not overrides:
             return
 

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -57,10 +57,16 @@ class AccountInvoiceTax(models.TransientModel):
         self._save_overrides()
 
         # --- 3. Apply overrides to the current tax lines ---
+        other_taxes_override = {}
+        for wizard_line in self.tax_line_ids.filtered(lambda l: l.tax_id.amount_type != "fixed"):
+            other_taxes_override[str(wizard_line.tax_id.id)] = {
+                "amount": wizard_line.amount,
+                "rate": self.move_id.invoice_currency_rate or 1.0,
+            }
         container = {"records": move}
         with move._check_balanced(container):
             with move._sync_dynamic_lines(container):
-                move._apply_tax_overrides()
+                move._apply_tax_overrides(other_taxes_override=other_taxes_override)
 
     def _save_overrides(self):
         """Write wizard line amounts into ``tax_override_data`` on the move.


### PR DESCRIPTION
… without persisting them

When coming from the tax wizard, percentage-based tax amounts are now applied to the invoice tax lines via `other_taxes_override` but are not stored in `tax_override_data`. This ensures that percentage taxes are recomputed automatically when the invoice changes, rather than retaining a stale manually-set value.