### PR TITLE
[IMP] account_background_post: better performance when setting background_post

### DIFF
--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -28,7 +28,12 @@ class ValidateAccountMove(models.TransientModel):
         return res
 
     def action_background_post(self):
-        self.move_ids.background_post = True
+        query = """
+            UPDATE account_move
+            SET background_post = true
+            WHERE id IN %s
+        """
+        self.env.cr.execute(query, (tuple(self.move_ids.ids),))
         self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
 
     def validate_move(self):


### PR DESCRIPTION
When setting the field `background_post` to True on multiple records, we were doing one write per record, which was very inefficient. Now we do a single update query to set the field to True for all the records at once.