### PR TITLE
[IMP] account_background_post: add visual indicators for pending background validation

### DIFF
--- a/account_background_post/views/account_move_views.xml
+++ b/account_background_post/views/account_move_views.xml
@@ -5,6 +5,9 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_out_invoice_tree" />
             <field name="arch" type="xml">
+                <xpath expr="//list" position="attributes">
+                    <attribute name="decoration-warning">background_post == True</attribute>
+                </xpath>
                 <field name="status_in_payment" position="before">
                     <field name="background_post" column_invisible="True"/>
                 </field>
@@ -19,6 +22,20 @@
                 <filter name="to_check" position="after">
                     <filter string="To validate in background" name="background_post" domain="[('background_post', '=', True)]"/>
                 </filter>
+            </field>
+        </record>
+
+        <record id="view_move_form" model="ir.ui.view">
+            <field name="name">account.move.form.inherit.background</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//form/sheet" position="before">
+                    <div class="alert alert-warning text-center" role="alert" invisible="not background_post">
+                        <strong>⚠️ This invoice is pending validation in background</strong>
+                        <p class="mb-0">This invoice will be automatically validated by the background process. If you validate it manually, the background flag will be automatically removed.</p>
+                    </div>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION

- Add decoration-warning to list view to highlight invoices with background_post flag
- Create new form view inheritance adding warning banner at top of invoice form
- Banner displays alert message when background_post is True
- Warning message explains automatic validation process and manual override behavior

Change note: Ahora puedes identificar fácilmente las facturas pendientes de validación en segundo plano. En la lista de facturas verás las filas resaltadas en color amarillo/naranja, y al abrir una factura pendiente aparecerá un cartel de advertencia en la parte superior indicando que será validada automáticamente.