### PR TITLE
[FIX] account_invoice_tax: fix swapped currency deltas in tax totals widget

### DIFF
--- a/account_invoice_tax/models/account_tax.py
+++ b/account_invoice_tax/models/account_tax.py
@@ -30,9 +30,9 @@ class AccountTax(models.Model):
                             "tax_amount_currency": new_amount,
                         }
                     )
-                    res["tax_amount"] += diff
-                    res["total_amount"] += diff
-                    res["tax_amount_currency"] += currency_diff
-                    res["total_amount_currency"] += currency_diff
+                    res["tax_amount"] += currency_diff
+                    res["total_amount"] += currency_diff
+                    res["tax_amount_currency"] += diff
+                    res["total_amount_currency"] += diff
 
         return res


### PR DESCRIPTION
- In `_get_tax_totals_summary`, `diff` (invoice-currency delta) and `currency_diff` (company-currency delta) were added to the wrong fields of the `res` dict: `diff` was added to `tax_amount` / `total_amount` (company currency) and `currency_diff` to `tax_amount_currency` / `total_amount_currency` (invoice currency).
- Swap assignments so each delta updates the correct field.

Change note: Se corrige un error visual en facturas de proveedor en moneda extranjera: al editar manualmente el importe de una percepción desde el asistente, el total mostrado en pantalla era incorrecto (por ej. 139.811 en vez de 1.310) hasta que se guardaba la factura. El importe ahora se refleja correctamente de forma inmediata.