### PR TITLE
[IMP] l10n_latam_invoice_document_ux: add journal constraint for posted moves

### DIFF
--- a/l10n_latam_invoice_document_ux/__init__.py
+++ b/l10n_latam_invoice_document_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_latam_invoice_document_ux/i18n/es_419.po
+++ b/l10n_latam_invoice_document_ux/i18n/es_419.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_latam_invoice_document_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-13 14:25+0000\n"
+"PO-Revision-Date: 2026-05-13 14:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_latam_invoice_document_ux
+#. odoo-python
+#: code:addons/l10n_latam_invoice_document_ux/models/account_move.py:0
+msgid "You cannot change the journal of a posted move (%s)."
+msgstr "No puede cambiar el diario de un asiento publicado (%s)."

--- a/l10n_latam_invoice_document_ux/i18n/l10n_latam_invoice_document_ux.pot
+++ b/l10n_latam_invoice_document_ux/i18n/l10n_latam_invoice_document_ux.pot
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_latam_invoice_document_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-13 14:25+0000\n"
+"PO-Revision-Date: 2026-05-13 14:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_latam_invoice_document_ux
+#. odoo-python
+#: code:addons/l10n_latam_invoice_document_ux/models/account_move.py:0
+msgid "You cannot change the journal of a posted move (%s)."
+msgstr ""

--- a/l10n_latam_invoice_document_ux/models/__init__.py
+++ b/l10n_latam_invoice_document_ux/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/l10n_latam_invoice_document_ux/models/account_move.py
+++ b/l10n_latam_invoice_document_ux/models/account_move.py
@@ -1,0 +1,15 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.constrains("journal_id")
+    def _check_journal(self):
+        """Check that the journal and the allows to post in the move's company."""
+        moves = self.filtered(lambda x: x.state == "posted" and x.journal_id.l10n_latam_use_documents)
+        if moves:
+            raise UserError(
+                _("You cannot change the journal of a posted move (%s).") % ", ".join(moves.mapped("display_name"))
+            )


### PR DESCRIPTION
…

- Add _check_journal constraint method to AccountMove
- Raises UserError when trying to change the journal of a posted move that uses LATAM documents, listing all affected move names
- Add i18n/l10n_latam_invoice_document_ux.pot and i18n/es.po translation files

Change note: Se agrega una validación que impide cambiar el diario de asientos publicados con documentos LATAM. Si se intenta el cambio, el sistema muestra un error con el nombre de todos los asientos afectados.