### PR TITLE
[FIX] account_invoice_tax: preserve user-entered negative tax amount

### DIFF
--- a/account_invoice_tax/__manifest__.py
+++ b/account_invoice_tax/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Invoice Tax",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "author": "ADHOC SA",
     "category": "Localization",
     "depends": [

--- a/account_invoice_tax/models/account_move.py
+++ b/account_invoice_tax/models/account_move.py
@@ -124,28 +124,25 @@ class AccountMove(models.Model):
         move_currency = self.currency_id
         company_currency = self.company_currency_id
         not_company_currency = move_currency and move_currency != company_currency
+        # Para in_invoice/in_receipt el impuesto positivo va al débito; para
+        # in_refund/out_* va al crédito. El signo se aplica una sola vez sobre
+        # el amount ingresado por el usuario (que puede ser negativo) y de ahí
+        # se derivan debit, credit y balance manteniendo la consistencia
+        # contable (debit - credit == balance).
+        sign = 1 if self.move_type in ("in_invoice", "in_receipt") else -1
         for line in self.line_ids.filtered(lambda l: l.tax_line_id and str(l.tax_line_id.id) in overrides):
             vals = overrides[str(line.tax_line_id.id)]
             rate = line.move_id.invoice_currency_rate or 1.0
             amount = vals.get("amount", 0.0)
             amount_cc = amount / rate
-            debit = credit = debit_cc = credit_cc = 0.0
-            if self.move_type in ("in_invoice", "in_receipt"):
-                if amount > 0:
-                    debit, debit_cc = amount, amount_cc
-                elif amount < 0:
-                    credit, credit_cc = -amount, -amount_cc
-            else:
-                if amount > 0:
-                    credit, credit_cc = amount, amount_cc
-                elif amount < 0:
-                    debit, debit_cc = -amount, -amount_cc
+            signed_amount = amount * sign
+            signed_amount_cc = amount_cc * sign
 
             line_vals = {
-                "debit": debit_cc if not_company_currency else debit,
-                "credit": credit_cc if not_company_currency else credit,
-                "balance": ((amount_cc if not_company_currency else amount) * (1 if debit or debit_cc else -1)),
+                "debit": max(signed_amount_cc, 0.0) if not_company_currency else max(signed_amount, 0.0),
+                "credit": max(-signed_amount_cc, 0.0) if not_company_currency else max(-signed_amount, 0.0),
+                "balance": signed_amount_cc if not_company_currency else signed_amount,
             }
             if not_company_currency and amount:
-                line_vals["amount_currency"] = amount * (1 if debit or debit_cc else -1)
+                line_vals["amount_currency"] = signed_amount
             line.write(line_vals)

--- a/account_invoice_tax/tests/__init__.py
+++ b/account_invoice_tax/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_invoice_tax

--- a/account_invoice_tax/tests/test_account_invoice_tax.py
+++ b/account_invoice_tax/tests/test_account_invoice_tax.py
@@ -1,0 +1,98 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountInvoiceTax(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.purchase_tax = cls.env["account.tax"].create(
+            {
+                "name": "VAT Purchase 21",
+                "amount_type": "percent",
+                "amount": 21.0,
+                "type_tax_use": "purchase",
+                "company_id": cls.env.company.id,
+            }
+        )
+        cls.sale_tax = cls.env["account.tax"].create(
+            {
+                "name": "VAT Sale 21",
+                "amount_type": "percent",
+                "amount": 21.0,
+                "type_tax_use": "sale",
+                "company_id": cls.env.company.id,
+            }
+        )
+
+    def _build_move(self, move_type, taxes):
+        return self._create_invoice_one_line(
+            move_type=move_type,
+            price_unit=1000.0,
+            tax_ids=taxes,
+        )
+
+    def _open_wizard(self, move):
+        return (
+            self.env["account.invoice.tax"]
+            .with_context(
+                active_model="account.move",
+                active_ids=move.ids,
+            )
+            .create({})
+        )
+
+    def _tax_line(self, move, tax):
+        return move.line_ids.filtered(lambda l: l.tax_line_id == tax)
+
+    def _set_amount_and_apply(self, move, amount):
+        wizard = self._open_wizard(move)
+        wizard.tax_line_ids.amount = amount
+        wizard.action_update_tax()
+        return self._tax_line(move, self.purchase_tax)
+
+    def test_in_invoice_positive_amount(self):
+        move = self._build_move("in_invoice", self.purchase_tax)
+        tax_line = self._set_amount_and_apply(move, 100.0)
+        self.assertEqual(tax_line.debit, 100.0)
+        self.assertEqual(tax_line.credit, 0.0)
+        self.assertEqual(tax_line.balance, 100.0)
+        self.assertEqual(tax_line.amount_currency, 100.0)
+
+    def test_in_invoice_negative_amount_keeps_negative(self):
+        """Ticket #116742: cargar -100 en wizard sobre in_invoice debe
+        preservar el signo negativo en balance y amount_currency."""
+        move = self._build_move("in_invoice", self.purchase_tax)
+        tax_line = self._set_amount_and_apply(move, -100.0)
+        self.assertEqual(tax_line.debit, 0.0)
+        self.assertEqual(tax_line.credit, 100.0)
+        self.assertEqual(tax_line.balance, -100.0)
+        self.assertEqual(tax_line.amount_currency, -100.0)
+
+    def test_in_refund_positive_amount(self):
+        move = self._build_move("in_refund", self.purchase_tax)
+        tax_line = self._set_amount_and_apply(move, 100.0)
+        self.assertEqual(tax_line.debit, 0.0)
+        self.assertEqual(tax_line.credit, 100.0)
+        self.assertEqual(tax_line.balance, -100.0)
+        self.assertEqual(tax_line.amount_currency, -100.0)
+
+    def test_in_refund_negative_amount_keeps_positive(self):
+        move = self._build_move("in_refund", self.purchase_tax)
+        tax_line = self._set_amount_and_apply(move, -100.0)
+        self.assertEqual(tax_line.debit, 100.0)
+        self.assertEqual(tax_line.credit, 0.0)
+        self.assertEqual(tax_line.balance, 100.0)
+        self.assertEqual(tax_line.amount_currency, 100.0)
+
+    def test_wizard_raises_on_out_invoice(self):
+        move = self._build_move("out_invoice", self.sale_tax)
+        with self.assertRaises(UserError):
+            self._open_wizard(move)
+
+    def test_wizard_raises_on_out_refund(self):
+        move = self._build_move("out_refund", self.sale_tax)
+        with self.assertRaises(UserError):
+            self._open_wizard(move)

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -21,8 +21,10 @@ class AccountInvoiceTax(models.TransientModel):
         res["move_id"] = move_ids[0].id if move_ids else False
         if move_ids[0].move_type == "in_invoice":
             sign = 1
-        else:  # For refund
+        elif move_ids[0].move_type == "in_refund":
             sign = -1
+        else:
+            raise UserError("Este asistente solo puede usarse sobre facturas o notas de crédito de compra.")
         lines = []
         for line in move_ids[0].line_ids.filtered(lambda x: x.tax_line_id):
             lines.append(


### PR DESCRIPTION
Previously `_apply_tax_overrides` redistributed a negative `amount` between debit and credit but flipped the sign of `balance` and `amount_currency`, so a tax line entered as -100 ended up stored as +100 on the opposite accounting side. The wizard appeared to accept negative amounts but the resulting move line was effectively positive.

Derive `debit`, `credit`, `balance` and `amount_currency` from a single signed amount so the sign entered by the user is preserved (consistent with native Odoo behavior, which already allows negative tax amounts).

Also raise `UserError` in `account.invoice.tax.default_get` when the wizard is opened on a move whose type is not `in_invoice` or `in_refund` — the wizard's tax domain already restricts taxes to `type_tax_use='purchase'`, so any other move type would silently produce inconsistent data.

Add `tests/` covering positive/negative amounts on `in_invoice` and `in_refund`, plus the new raise on `out_invoice` / `out_refund`.

Change note: corrige el asistente "Actualizar impuestos" para que un monto negativo ingresado por el usuario se mantenga negativo en el apunte contable (alineado al funcionamiento nativo de Odoo, que permite impuestos negativos). Antes el monto se convertía a positivo del lado opuesto. Además, ahora el asistente solo puede abrirse sobre facturas o notas de crédito de compra; en otros tipos de asiento levanta un error explícito.