### PR TITLE
[FIX] account_invoice_tax: skip tax override on posted moves

### DIFF
--- a/account_invoice_tax/models/account_move.py
+++ b/account_invoice_tax/models/account_move.py
@@ -118,7 +118,7 @@ class AccountMove(models.Model):
             # as they don't need to survive recomputations, but we still want to
             # apply them on the current tax lines.
             overrides.update(other_taxes_override)
-        if not overrides:
+        if not overrides or self.state == "posted":
             return
 
         move_currency = self.currency_id


### PR DESCRIPTION
Prevent _apply_tax_overrides() from re-applying manually-set tax amounts after a move has already been confirmed (state == 'posted').

Without this guard, any recomputation triggered on a posted move (e.g. currency rate updates) would overwrite amounts that should no longer be editable, potentially altering the posted accounting entries.