### PR TITLE
[IMP] account_lock_posted_moves: avoid full table scan on post_init_hook   

### DIFF
--- a/account_lock_posted_moves/__init__.py
+++ b/account_lock_posted_moves/__init__.py
@@ -12,33 +12,43 @@ _logger = logging.getLogger(__name__)
 def post_init_hook(env):
     """Migrate from hash system to lock_posted_moves (compatible with v19)."""
     cr = env.cr
-    cr.execute("SELECT * FROM account_move WHERE inalterable_hash IS NOT NULL LIMIT 1")
+
+    # Check whether the source column exists (absent in fresh v19 installs)
+    cr.execute(
+        "SELECT 1 FROM information_schema.columns"
+        " WHERE table_name = 'account_move' AND column_name = 'inalterable_hash'"
+    )
     if cr.fetchone():
-        # Create backup column if it doesn't exist
+        # Check idempotency: backup already present means migration already ran
         cr.execute(
-            "SELECT 1 FROM information_schema.columns WHERE table_name = 'account_move' AND column_name = 'x_bkp_inalterable_hash'"
+            "SELECT 1 FROM information_schema.columns"
+            " WHERE table_name = 'account_move' AND column_name = 'x_bkp_inalterable_hash'"
         )
         if not cr.fetchone():
-            cr.execute("ALTER TABLE account_move ADD COLUMN x_bkp_inalterable_hash VARCHAR")
-
-        # Copy hash values to backup (equivalent to openupgrade.copy_columns)
-        cr.execute(
-            "UPDATE account_move SET x_bkp_inalterable_hash = inalterable_hash WHERE inalterable_hash IS NOT NULL"
-        )
-
-        # Clean inalterable_hash
-        cr.execute("UPDATE account_move SET inalterable_hash = NULL WHERE inalterable_hash IS NOT NULL")
-        _logger.info(
-            "account_lock_posted_moves: cleaned inalterable_hash (%s records, backup preserved in x_bkp_inalterable_hash)",
-            cr.rowcount,
-        )
+            # RENAME COLUMN + ADD COLUMN are O(1) catalog operations — no row scan.
+            # Avoids a full-table UPDATE that causes install timeouts on large databases.
+            cr.execute("ALTER TABLE account_move RENAME COLUMN inalterable_hash TO x_bkp_inalterable_hash")
+            cr.execute("ALTER TABLE account_move ADD COLUMN inalterable_hash VARCHAR")
+            _logger.info("account_lock_posted_moves: renamed inalterable_hash → x_bkp_inalterable_hash (no row scan)")
+        else:
+            # Backup column already exists: copy remaining non-null hashes and clear the source.
+            cr.execute("""
+                UPDATE account_move
+                   SET x_bkp_inalterable_hash = inalterable_hash,
+                       inalterable_hash = NULL
+                 WHERE inalterable_hash IS NOT NULL
+            """)
+            _logger.info(
+                "account_lock_posted_moves: cleaned inalterable_hash (%s records, backup preserved in x_bkp_inalterable_hash)",
+                cr.rowcount,
+            )
     else:
-        _logger.info("account_lock_posted_moves: no hash values found to backup")
+        _logger.info("account_lock_posted_moves: inalterable_hash column not present, nothing to migrate")
 
-    # Migrate lock_posted_moves values based on restrict_mode_hash_table
-    cr.execute(
-        "UPDATE account_journal SET lock_posted_moves = restrict_mode_hash_table WHERE restrict_mode_hash_table = TRUE"
-    )
-
-    cr.execute("UPDATE account_journal SET restrict_mode_hash_table = FALSE WHERE restrict_mode_hash_table = TRUE")
+    cr.execute("""
+        UPDATE account_journal
+           SET lock_posted_moves = TRUE,
+               restrict_mode_hash_table = FALSE
+         WHERE restrict_mode_hash_table = TRUE
+    """)
     _logger.info("account_lock_posted_moves: deprecated %s journals", cr.rowcount)


### PR DESCRIPTION
Replace UPDATE-based hash migration with RENAME COLUMN + ADD COLUMN,
which are O(1) catalog operations in PostgreSQL. Falls back to the
original UPDATE when the backup column already exists.