### PR TITLE
[FIX] account_invoice_tax: negative tax amount goes to debit instead of credit

### DIFF
--- a/account_invoice_tax/models/account_move.py
+++ b/account_invoice_tax/models/account_move.py
@@ -207,11 +207,18 @@ class AccountMove(models.Model):
                 elif amount < 0:
                     debit, debit_cc = -amount, -amount_cc
 
+            sign = 1 if debit or debit_cc else -1
+            # When in_invoice/in_receipt and amount < 0, the value is placed in
+            # credit (debit=0), making sign=-1. That double-negates amount_cc and
+            # produces a positive balance (debit side) instead of credit. Force
+            # sign=1 so the negative amount stays on the credit side.
+            if self.move_type in ("in_invoice", "in_receipt") and amount < 0:
+                sign = 1
             line_vals = {
                 "debit": debit_cc if not_company_currency else debit,
                 "credit": credit_cc if not_company_currency else credit,
-                "balance": ((amount_cc if not_company_currency else amount) * (1 if debit or debit_cc else -1)),
+                "balance": (amount_cc if not_company_currency else amount) * sign,
             }
             if not_company_currency and amount:
-                line_vals["amount_currency"] = amount * (1 if debit or debit_cc else -1)
+                line_vals["amount_currency"] = amount * sign
             line.write(line_vals)


### PR DESCRIPTION
## Problema

Al agregar un impuesto manual con monto negativo (ej. -10.00) en una factura de proveedor borrador, el apunte contable resultante registraba el valor en el **Debe** ($10) en vez del **Haber**, dejando el asiento desbalanceado.

## Causa raíz

En `_apply_tax_overrides` (`account_invoice_tax/models/account_move.py`), el `balance` se calculaba con:

\`\`\`python
amount_cc * (1 if debit or debit_cc else -1)
\`\`\`

Para `amount = -10` en un `in_invoice`, el monto negativo se asigna a la variable `credit` (no a `debit`), por lo que `debit = 0` y el multiplicador cae en `-1`. La doble negación produce un balance positivo:

- multiplicador = `-1` (porque `debit = 0`)
- `balance = -10 * -1 = +10` → **Debe** ✗

El mismo error afecta a `amount_currency` en facturas con moneda extranjera.

Este bug **no existe** en `in_refund` ni `out_invoice`: en esos tipos los montos negativos se asignan a `debit` (no a `credit`), por lo que el multiplicador es `+1` y el signo se preserva correctamente.

## Fix

Se agrega una condición puntual para forzar `sign = 1` únicamente en el caso roto (`in_invoice`/`in_receipt` con `amount < 0`). El resto de la función queda sin cambios:

\`\`\`python
sign = 1 if debit or debit_cc else -1
if self.move_type in ("in_invoice", "in_receipt") and amount < 0:
    sign = 1
\`\`\`

Para `amount = -10`, `in_invoice`: `balance = -10 * 1 = -10` → **Haber** ✓

## Casos verificados

| move_type | amount | Antes | Después |
|---|---|---|---|
| `in_invoice` | -10 | +10 Debe ✗ | -10 Haber ✓ |
| `in_invoice` | +21 | +21 Debe ✓ | +21 Debe ✓ (sin cambio) |
| `in_refund` | -10 | -10 Haber ✓ | -10 Haber ✓ (sin cambio) |
| `out_invoice` | +21 | -21 Haber ✓ | -21 Haber ✓ (sin cambio) |