### PR TITLE
[ADD] account_invoice_send_recipients: send invoices to several customer recipients

### DIFF
--- a/account_invoice_send_recipients/README.rst
+++ b/account_invoice_send_recipients/README.rst
@@ -1,0 +1,77 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================
+Account Invoice Send Recipients
+===============================
+
+* Adds a "Receive Invoices by Email" flag on contacts, available both on the main contact form and on the subcontact popup (any contact type).
+* When sending a customer invoice or refund, automatically adds the customer contacts flagged with that field (and with an email) as recipients, on top of the default ones.
+* Captures the whole contact hierarchy of the customer (sub-subcontacts included) via ``commercial_partner_id``, regardless of nesting or contact type.
+* Covers the three sending paths with a single extension point: individual send, batch send and automatic (cron) send.
+* Non-intrusive: recipients are pre-loaded but the field stays editable, so the user can remove them before sending.
+* Scope: customer invoices and credit notes (``out_invoice`` / ``out_refund``).
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to the customer contact (or any of its subcontacts) and enable "Receive Invoices by Email"
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Create and confirm a customer invoice (or credit note) for that customer
+#. Send the invoice by email: the flagged contacts are pre-loaded as recipients along with the default one
+#. If needed, remove any recipient before sending
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/account_invoice_send_recipients/__init__.py
+++ b/account_invoice_send_recipients/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_send_recipients/__manifest__.py
+++ b/account_invoice_send_recipients/__manifest__.py
@@ -1,0 +1,32 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Account Invoice Send Recipients",
+    "author": "ADHOC SA",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "category": "Accounting & Finance",
+    "depends": ["account"],
+    "data": [
+        "views/res_partner_views.xml",
+    ],
+    "website": "www.adhoc.com.ar",
+    "installable": True,
+}

--- a/account_invoice_send_recipients/models/__init__.py
+++ b/account_invoice_send_recipients/models/__init__.py
@@ -1,0 +1,3 @@
+from . import res_partner
+from . import account_move
+from . import account_move_send

--- a/account_invoice_send_recipients/models/account_move.py
+++ b/account_invoice_send_recipients/models/account_move.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_invoice_extra_recipients(self):
+        self.ensure_one()
+        if self.move_type not in ("out_invoice", "out_refund"):
+            return self.env["res.partner"]
+        return self.env["res.partner"].search(
+            [
+                ("commercial_partner_id", "=", self.commercial_partner_id.id),
+                ("send_invoice_by_email", "=", True),
+                ("email", "!=", False),
+            ]
+        )

--- a/account_invoice_send_recipients/models/account_move_send.py
+++ b/account_invoice_send_recipients/models/account_move_send.py
@@ -1,0 +1,10 @@
+from odoo import api, models
+
+
+class AccountMoveSend(models.AbstractModel):
+    _inherit = "account.move.send"
+
+    @api.model
+    def _get_default_mail_partner_ids(self, move, mail_template, mail_lang):
+        partners = super()._get_default_mail_partner_ids(move, mail_template, mail_lang)
+        return partners | move._get_invoice_extra_recipients()

--- a/account_invoice_send_recipients/models/res_partner.py
+++ b/account_invoice_send_recipients/models/res_partner.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    send_invoice_by_email = fields.Boolean(
+        string="Receive Invoices by Email",
+        help="If enabled, this contact is automatically added as a recipient "
+        "when sending invoices of the customer it belongs to.",
+    )

--- a/account_invoice_send_recipients/tests/__init__.py
+++ b/account_invoice_send_recipients/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_invoice_send_recipients

--- a/account_invoice_send_recipients/tests/test_invoice_send_recipients.py
+++ b/account_invoice_send_recipients/tests/test_invoice_send_recipients.py
@@ -1,0 +1,101 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInvoiceSendRecipients(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer = cls.env["res.partner"].create(
+            {
+                "name": "Customer Company",
+                "is_company": True,
+                "email": "company@example.com",
+            }
+        )
+        cls.accountant = cls.env["res.partner"].create(
+            {
+                "name": "Accountant",
+                "parent_id": cls.customer.id,
+                "type": "contact",
+                "email": "accountant@example.com",
+                "send_invoice_by_email": True,
+            }
+        )
+        cls.admin_office = cls.env["res.partner"].create(
+            {
+                "name": "Admin Office",
+                "parent_id": cls.accountant.id,
+                "type": "invoice",
+                "email": "admin@example.com",
+                "send_invoice_by_email": True,
+            }
+        )
+        cls.no_email = cls.env["res.partner"].create(
+            {
+                "name": "No Email",
+                "parent_id": cls.customer.id,
+                "email": False,
+                "send_invoice_by_email": True,
+            }
+        )
+        cls.not_flagged = cls.env["res.partner"].create(
+            {
+                "name": "Not Flagged",
+                "parent_id": cls.customer.id,
+                "email": "other@example.com",
+                "send_invoice_by_email": False,
+            }
+        )
+
+    def _create_invoice(self, move_type, post=True):
+        return self.init_invoice(
+            move_type,
+            partner=self.customer,
+            products=self.product_a,
+            post=post,
+        )
+
+    def test_extra_recipients_out_invoice(self):
+        invoice = self._create_invoice("out_invoice")
+        recipients = invoice._get_invoice_extra_recipients()
+        self.assertEqual(recipients, self.accountant | self.admin_office)
+        self.assertNotIn(self.no_email, recipients)
+        self.assertNotIn(self.not_flagged, recipients)
+
+    def test_extra_recipients_out_refund(self):
+        refund = self._create_invoice("out_refund")
+        self.assertEqual(
+            refund._get_invoice_extra_recipients(),
+            self.accountant | self.admin_office,
+        )
+
+    def test_extra_recipients_vendor_bill_empty(self):
+        bill = self.init_invoice(
+            "in_invoice",
+            partner=self.customer,
+            products=self.product_a,
+            post=True,
+        )
+        self.assertFalse(bill._get_invoice_extra_recipients())
+
+    def test_wizard_includes_extra_recipients_without_duplicates(self):
+        self.customer.send_invoice_by_email = True
+        invoice = self._create_invoice("out_invoice")
+        wizard = (
+            self.env["account.move.send.wizard"]
+            .with_context(
+                active_model="account.move",
+                active_ids=invoice.ids,
+            )
+            .create({"move_id": invoice.id})
+        )
+
+        partners = wizard.mail_partner_ids
+        self.assertIn(self.customer, partners)
+        self.assertIn(self.accountant, partners)
+        self.assertIn(self.admin_office, partners)
+        self.assertNotIn(self.no_email, partners)
+        self.assertNotIn(self.not_flagged, partners)
+        self.assertEqual(len(partners), len(set(partners.ids)))

--- a/account_invoice_send_recipients/views/res_partner_views.xml
+++ b/account_invoice_send_recipients/views/res_partner_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form - send_invoice_by_email</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="website" position="after">
+                <field name="send_invoice_by_email" invisible="not parent_id"/>
+            </field>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='email']" position="after">
+                <field name="send_invoice_by_email"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What it does

New module that, when sending a customer invoice or refund (`out_invoice` / `out_refund`), automatically adds the customer subcontacts flagged with **"Receive Invoices by Email"** as recipients, on top of the default ones. No manual selection.

- Boolean flag `send_invoice_by_email` on `res.partner`, shown only on subcontacts (those with a parent) on the contact form and on the subcontact popup (any `type`).
- Captures the whole customer hierarchy via `commercial_partner_id` (sub-subcontacts included).
- A single override of `account.move.send._get_default_mail_partner_ids` covers **individual + batch + automatic (cron)** sending.
- Non-intrusive: recipients are pre-loaded but the field stays editable; the user can remove them before sending.
- `account.move._get_invoice_extra_recipients` hook designed to scale to other documents (e.g. sale order confirmation) reusing the same flag.

## Scope

- **v1:** `out_invoice` / `out_refund` only.
- Out of scope: sale order confirmation and other documents (designed to scale).

## Tests

`tests/test_invoice_send_recipients.py` (TransactionCase on `AccountTestInvoicingCommon`, data built with `.create()`):

- `out_invoice` → returns the flagged contacts with email; excludes no-email and non-flagged.
- `out_refund` → same behavior.
- `in_invoice` → empty (respects scope).
- Integration through `account.move.send.wizard` → main partner + flagged, no duplicates.

Verified locally: `0 failed, 0 error(s) of 4 tests`.

Task 69727