### PR TITLE
[FIX] l10n_latam_invoice_document_ux: avoid false sequence-gap flag on document moves

### DIFF
--- a/l10n_latam_invoice_document_ux/__manifest__.py
+++ b/l10n_latam_invoice_document_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Latam Invoice Document UX",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_latam_invoice_document_ux/migrations/19.0.1.3.0/post-migration.py
+++ b/l10n_latam_invoice_document_ux/migrations/19.0.1.3.0/post-migration.py
@@ -1,0 +1,35 @@
+import logging
+
+from dateutil.relativedelta import relativedelta
+from odoo import SUPERUSER_ID, api, fields
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Limpia la falsa marca de salto de secuencia (`made_sequence_gap`) en comprobantes cuyo diario
+    usa documentos, de los últimos 2 meses.
+
+    En v19 el cálculo del flag pasó a `_update_sequence_made_gap`, pero la exclusión que
+    `l10n_latam_invoice_document` aplicaba a los comprobantes con documentos no se trasladó al
+    método nuevo, así que volvieron a marcarse en rojo. El override (ver models/account_move.py)
+    lo corrige de acá en adelante; esta migración limpia las ya almacenadas.
+
+    Re-ejecutable: solo toca registros que todavía tengan `made_sequence_gap = True`.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cutoff = fields.Date.today() - relativedelta(months=2)
+    moves = env["account.move"].search(
+        [
+            ("l10n_latam_use_documents", "=", True),
+            ("made_sequence_gap", "=", True),
+            ("invoice_date", ">=", cutoff),
+        ]
+    )
+    if moves:
+        moves.made_sequence_gap = False
+        _logger.info(
+            "l10n_latam_invoice_document_ux: limpiada la falsa marca made_sequence_gap en %s comprobantes desde %s",
+            len(moves),
+            cutoff,
+        )

--- a/l10n_latam_invoice_document_ux/models/account_move.py
+++ b/l10n_latam_invoice_document_ux/models/account_move.py
@@ -13,3 +13,20 @@ class AccountMove(models.Model):
             raise UserError(
                 _("You cannot change the journal of a posted move (%s).") % ", ".join(moves.mapped("display_name"))
             )
+
+    def _update_sequence_made_gap(self, invalidate_current=False):
+        """Los comprobantes cuyo diario usa documentos toman su numeración del documento, no de una
+        secuencia administrada por el diario, por lo que los "saltos de secuencia" son normales y no
+        deben marcarlos en rojo (decoration-danger).
+
+        En v18 el flag lo computaba `_compute_made_sequence_gap` y `l10n_latam_invoice_document`
+        ya excluía estos comprobantes. En v19 el cálculo se movió a `_update_sequence_made_gap`,
+        pero el guard de upstream quedó sobre los métodos deprecados (`_compute_made_sequence_gap`
+        y `_set_next_made_sequence_gap`), que ya no se ejecutan, dejándolo sin efecto. Reaplicamos
+        acá la exclusión (mismo criterio que v18: todo comprobante con `l10n_latam_use_documents`)
+        hasta que Odoo lo corrija upstream.
+        """
+        use_documents_moves = self.filtered(lambda m: m.l10n_latam_use_documents)
+        use_documents_moves.made_sequence_gap = False
+        if other_moves := self - use_documents_moves:
+            super(AccountMove, other_moves)._update_sequence_made_gap(invalidate_current=invalidate_current)


### PR DESCRIPTION
## Problema

En v19 los comprobantes cuyo diario usa documentos (facturas de proveedor y de cliente) aparecen marcados en rojo (`decoration-danger`) en la lista, como si rompieran la secuencia del diario. Su numeración proviene del documento, no de una secuencia administrada por el diario, por lo que los "saltos" son normales.

## Causa

El flag `made_sequence_gap` en v18 lo computaba `_compute_made_sequence_gap`, y `l10n_latam_invoice_document` ya excluía de ese cálculo a los comprobantes con `l10n_latam_use_documents`. En v19 el cálculo se movió a `_update_sequence_made_gap`, pero el guard de upstream quedó solo sobre los métodos ahora deprecados (`_compute_made_sequence_gap` / `_set_next_made_sequence_gap`), que ya no se ejecutan. El guard quedó sin efecto.

Es un bug de Odoo upstream (la localización LatAm no se actualizó al refactor de v19) y afecta a **todas** las localizaciones LatAm que usan documentos, no solo a Argentina. Por eso el fix vive en el layer LatAm (`l10n_latam_invoice_document_ux`) y no en un módulo de una localización puntual.

## Solución

- Override de `_update_sequence_made_gap` que excluye los comprobantes con `l10n_latam_use_documents` (les fija `made_sequence_gap = False`) y delega al `super` para el resto, replicando el criterio de v18.
- Post-migration (`19.0.1.3.0`) que limpia el falso flag en los comprobantes con documentos de los últimos 2 meses ya almacenados. Re-ejecutable.

## Test plan

- En una base LatAm con documentos, cargar varios comprobantes (facturas de proveedor y de cliente) con números de documento no consecutivos y confirmarlos → no deben quedar marcados en rojo en la lista.
- Verificar que comprobantes que **no** usan documentos (diarios con secuencia administrada) siguen marcando el salto de secuencia normalmente.
- Actualizar el módulo sobre una base con comprobantes previos marcados en rojo → la migración los limpia (últimos 2 meses).

## Merge

Incluye migration script → corresponde mergear con `bump`.