### PR TITLE
[FIX] account_invoice_partial: show Invoice Percentage button on vendor bills

### DIFF
--- a/account_invoice_partial/__manifest__.py
+++ b/account_invoice_partial/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Invoice Partial",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_invoice_partial/views/account_move_views.xml
+++ b/account_invoice_partial/views/account_move_views.xml
@@ -9,7 +9,7 @@
             <button name="action_post" position="after">
                 <button
                     name="%(action_account_invoice_partial_wizard_form)d"
-                    invisible="state != 'draft' or move_type not in ('out_invoice', 'out_refund')"
+                    invisible="state != 'draft' or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
                     string="Invoice Percentage"
                     type="action"
                 />


### PR DESCRIPTION
El botón **"Invoice Percentage"** del módulo `account_invoice_partial` no aparece en facturas ni notas de crédito de proveedor, cuando sí estaba disponible hasta v16.

## Causa

En la migración a 17.0 (commit `4e1726c`, PR #173) se reemplazó el atributo deprecado `states="draft"` por `invisible` y, en el mismo cambio, se agregó la condición `move_type not in ('out_invoice', 'out_refund')`. Eso limitó el botón a comprobantes de cliente y lo sacó de los de proveedor (`in_invoice`, `in_refund`). No hay justificación documentada para esa restricción.

## Cambio

Se amplía la condición de visibilidad a `('out_invoice', 'out_refund', 'in_invoice', 'in_refund')`.

El wizard `account.invoice.partial.wizard` es agnóstico al tipo de comprobante: solo escala `line.quantity` por el porcentaje indicado sobre `invoice_line_ids`, sin asumir signos, cuentas ni impuestos de ventas. Por lo tanto funciona igual en compras.

## Test plan

1. Instalar `account_invoice_partial`.
2. Abrir una factura de proveedor en borrador → el botón **"Invoice Percentage"** ahora aparece.
3. Ejecutar el wizard con un porcentaje (ej. 50%) → las cantidades de las líneas se escalan correctamente.
4. Verificar que en facturas/NC de cliente sigue funcionando igual.

## Versiones

- Fix sobre 18.0.
- Forward-port a 19.0.

Refs: I+D task #70288 / helpdesk ticket #121285.