### PR TITLE
[IMP] account_background_post: defer out_invoice/out_refund posting v…

### DIFF
--- a/account_background_post/models/account_move.py
+++ b/account_background_post/models/account_move.py
@@ -49,7 +49,17 @@ class AccountMove(models.Model):
                 self.env.cr.commit()  # pylint: disable=invalid-commit
 
     def _post(self, soft=True):
-        posted = super()._post(soft=soft)
+        """Difiere el posteo de documentos de venta (facturas y notas de crédito) a background,
+        para no bloquear el flujo sincrónico por validaciones externas lentas (ej. ARCA).
+
+        Si el contexto trae `force_background_post`, saltea el `super()._post()` para facturas
+        de cliente y notas de crédito/débito de venta (`out_invoice`, `out_refund`); el resto
+        de los moves postea normalmente."""
+        to_defer = self.env["account.move"]
+        if self.env.context.get("force_background_post"):
+            to_defer = self.filtered(lambda m: m.move_type in ("out_invoice", "out_refund"))
+            to_defer.write({"background_post": True})
+        posted = super(AccountMove, self - to_defer)._post(soft=soft)
         posted.filtered("background_post").background_post = False
         return posted
 


### PR DESCRIPTION
…ia force_background_post

Allows callers to defer posting of customer invoices and credit notes to the background cron via context, so slow synchronous validations (e.g. ARCA) don't block the caller flow. Other move types post normally.