### PR TITLE
[ADD] l10n_latam_invoice_document_ux: backport from 19.0

### DIFF
--- a/l10n_latam_invoice_document_ux/README.rst
+++ b/l10n_latam_invoice_document_ux/README.rst
@@ -1,0 +1,73 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=============================
+Latam Invoice Document UX
+=============================
+
+This module improves the user experience for LATAM invoice documents by making document type and document number fields required at validation time instead of at form level.
+
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+This module modifies the validation behavior of LATAM invoice documents:
+
+#. Document type and document number fields are now required when validating invoices with manual numbering
+#. This allows users to fill in the form without being forced to enter these fields immediately
+#. The validation ensures data integrity when the invoice is posted
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_latam_invoice_document_ux/__init__.py
+++ b/l10n_latam_invoice_document_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_latam_invoice_document_ux/__manifest__.py
+++ b/l10n_latam_invoice_document_ux/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Latam Invoice Document UX",
+    "version": "18.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Localization",
+    "depends": [
+        "l10n_latam_invoice_document",
+    ],
+    "data": [
+        "views/account_move_view.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/l10n_latam_invoice_document_ux/i18n/es_419.po
+++ b/l10n_latam_invoice_document_ux/i18n/es_419.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_latam_invoice_document_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-13 14:25+0000\n"
+"PO-Revision-Date: 2026-05-13 14:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_latam_invoice_document_ux
+#. odoo-python
+#: code:addons/l10n_latam_invoice_document_ux/models/account_move.py:0
+msgid "You cannot change the journal of a posted move (%s)."
+msgstr "No puede cambiar el diario de un asiento publicado (%s)."

--- a/l10n_latam_invoice_document_ux/i18n/l10n_latam_invoice_document_ux.pot
+++ b/l10n_latam_invoice_document_ux/i18n/l10n_latam_invoice_document_ux.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_latam_invoice_document_ux
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-13 20:45+0000\n"
+"PO-Revision-Date: 2026-05-13 20:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_latam_invoice_document_ux
+#: model:ir.model.fields,field_description:l10n_latam_invoice_document_ux.field_account_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_latam_invoice_document_ux
+#: model:ir.model.fields,field_description:l10n_latam_invoice_document_ux.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_latam_invoice_document_ux
+#: model:ir.model,name:l10n_latam_invoice_document_ux.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_latam_invoice_document_ux
+#. odoo-python
+#: code:addons/l10n_latam_invoice_document_ux/models/account_move.py:0
+msgid "You cannot change the journal of a posted move (%s)."
+msgstr ""

--- a/l10n_latam_invoice_document_ux/models/__init__.py
+++ b/l10n_latam_invoice_document_ux/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/l10n_latam_invoice_document_ux/models/account_move.py
+++ b/l10n_latam_invoice_document_ux/models/account_move.py
@@ -1,0 +1,15 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.constrains("journal_id")
+    def _check_journal(self):
+        """Check that the journal and the allows to post in the move's company."""
+        moves = self.filtered(lambda x: x.state == "posted" and x.journal_id.l10n_latam_use_documents)
+        if moves:
+            raise UserError(
+                _("You cannot change the journal of a posted move (%s).") % ", ".join(moves.mapped("display_name"))
+            )

--- a/l10n_latam_invoice_document_ux/tests/__init__.py
+++ b/l10n_latam_invoice_document_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_patch_l10n_ar

--- a/l10n_latam_invoice_document_ux/tests/test_patch_l10n_ar.py
+++ b/l10n_latam_invoice_document_ux/tests/test_patch_l10n_ar.py
@@ -1,0 +1,145 @@
+from odoo import tools
+from odoo.exceptions import ValidationError
+from odoo.tests import Form, common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPatchDummy(common.TransactionCase):
+    def test_dummy(self):
+        # a trivial test so the test runner reports >0 tests (avoids the 0-tests warning)
+        self.assertTrue(True)
+
+
+# Only apply the patch while running tests
+if tools.config.get("test_enable"):
+    from odoo.addons.l10n_ar.tests.test_manual import TestArManual
+
+    def test_15_liquido_producto_sales_patch(self):
+        """Patcheamos para que la validacion se haga al momento de validar la factura y no antes"""
+
+        # Verify that the default sales journals ara created as is ARCA POS
+        self.assertTrue(self.journal.l10n_ar_is_pos)
+
+        # If we create an invoice it will not use manual numbering
+        invoice = self._create_invoice_ar()
+        self.assertFalse(invoice.l10n_latam_manual_document_number)
+
+        # Create a new sale journal that is not ARCA POS
+        self.journal = self._create_journal("preprinted", data={"l10n_ar_is_pos": False})
+        self.assertFalse(self.journal.l10n_ar_is_pos)
+
+        doc_27_lu_a = self.env.ref("l10n_ar.dc_liq_uci_a")
+        payment_term_id = self.env.ref("account.account_payment_term_end_following_month")
+
+        # 60, 61, 27, 28, 45, 46
+        # In this case manual numbering should be True and the latam document numer should be required
+        with Form(self.env["account.move"].with_context(default_move_type="out_invoice")) as invoice_form:
+            invoice_form.ref = "demo_liquido_producto_1: Vendor bill liquido producto (DOC 186)"
+            invoice_form.partner_id = self.res_partner_adhoc
+            invoice_form.invoice_payment_term_id = payment_term_id
+            invoice_form.journal_id = self.journal
+            invoice_form.l10n_latam_document_type_id = doc_27_lu_a
+            with invoice_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.env.ref("product.product_product_4")
+                line_form.quantity = 1
+                line_form.price_unit = 100
+        invoice = invoice_form.save()
+
+        # Should fail when posting without document number
+        with self.assertRaisesRegex(ValidationError, "Please set the document number"):
+            invoice.action_post()
+
+        # Adding the document number will let us to save and validate the number without any problems
+        with Form(self.env["account.move"].with_context(default_move_type="out_invoice")) as invoice_form:
+            invoice_form.ref = "demo_liquido_producto_1: Vendor bill liquido producto (DOC 186)"
+            invoice_form.partner_id = self.res_partner_adhoc
+            invoice_form.invoice_payment_term_id = payment_term_id
+            invoice_form.journal_id = self.journal
+            invoice_form.l10n_latam_document_type_id = doc_27_lu_a
+            invoice_form.l10n_latam_document_number = "00077-00000077"
+            with invoice_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.env.ref("product.product_product_4")
+                line_form.quantity = 1
+                line_form.price_unit = 100
+        invoice = invoice_form.save()
+        invoice.action_post()
+
+    def test_16_liquido_producto_purchase_patch(self):
+        """Patcheamos para que la validacion se haga al momento de validar la factura y no antes"""
+
+        # By default purchase journals ar not ARCA POS journal
+        purchase_not_pos_journal = self.env["account.journal"].search(
+            [
+                ("type", "=", "purchase"),
+                ("company_id", "=", self.env.company.id),
+                ("l10n_latam_use_documents", "=", True),
+            ]
+        )
+        self.assertFalse(purchase_not_pos_journal.l10n_ar_is_pos)
+
+        doc_60_lp_a = self.env.ref("l10n_ar.dc_a_cvl")
+        payment_term_id = self.env.ref("account.account_payment_term_end_following_month")
+
+        with Form(self.env["account.move"].with_context(default_move_type="in_invoice")) as bill_form:
+            bill_form.ref = "demo_liquido_producto_1: Vendor bill liquido producto (DOC 186)"
+            bill_form.partner_id = self.res_partner_adhoc
+            bill_form.invoice_payment_term_id = payment_term_id
+            bill_form.invoice_date = "2023-02-09"
+            bill_form.l10n_latam_document_type_id = doc_60_lp_a
+            with bill_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.env.ref("product.product_product_4")
+                line_form.quantity = 1
+                line_form.price_unit = 100
+        bill = bill_form.save()
+
+        self.assertEqual(bill.journal_id, purchase_not_pos_journal)
+
+        # Should fail when posting without document number
+        with self.assertRaisesRegex(ValidationError, "Please set the document number"):
+            bill.action_post()
+
+        # Create a new journal that is an ARCA POS
+        purchase_pos_journal = self._create_journal("preprinted", data={"type": "purchase", "l10n_ar_is_pos": True})
+
+        with Form(self.env["account.move"].with_context(default_move_type="in_invoice")) as bill_form:
+            bill_form.ref = "demo_liquido_producto_1: Vendor bill liquido producto (DOC 186)"
+            bill_form.partner_id = self.res_partner_adhoc
+            bill_form.invoice_payment_term_id = payment_term_id
+            bill_form.invoice_date = "2023-02-09"
+            bill_form.journal_id = purchase_pos_journal
+            bill_form.l10n_latam_document_type_id = doc_60_lp_a
+            bill_form.l10n_latam_document_number = "00077-00000077"
+            with bill_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.env.ref("product.product_product_4")
+                line_form.quantity = 1
+                line_form.price_unit = 100
+        bill = bill_form.save()
+        bill.action_post()
+
+        # If we create an invoice it will not use manual numbering
+        self.assertFalse(bill.l10n_latam_manual_document_number)
+
+    def propagate(method1, method2):
+        if method1:
+            for attr in ("_returns",):
+                if hasattr(method1, attr) and not hasattr(method2, attr):
+                    setattr(method2, attr, getattr(method1, attr))
+        return method2
+
+    def _patch_method(cls, name, method):
+        origin = getattr(cls, name)
+        method.origin = origin
+        wrapped = propagate(origin, method)
+        wrapped.origin = origin
+        setattr(cls, name, wrapped)
+
+    _patch_method(
+        TestArManual,
+        "test_15_liquido_producto_sales",
+        test_15_liquido_producto_sales_patch,
+    )
+    _patch_method(
+        TestArManual,
+        "test_16_liquido_producto_purchase",
+        test_16_liquido_producto_purchase_patch,
+    )

--- a/l10n_latam_invoice_document_ux/views/account_move_view.xml
+++ b/l10n_latam_invoice_document_ux/views/account_move_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="l10n_latam_invoice_document.view_move_form"/>
+        <field name="arch" type="xml">
+            <!-- Solo hacemos requeridos estos campo cuando validamos la factura, no antes-->
+            <field name="l10n_latam_document_number" position="attributes">
+                <attribute name="required"/>
+            </field>
+            <field name="l10n_latam_document_type_id" position="attributes">
+                <attribute name="required"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What

Backport of the `l10n_latam_invoice_document_ux` module from 19.0 to 18.0.

## Why

The document type and document number fields are `required` at form level in `l10n_latam_invoice_document`. This makes it impossible to reset a posted move to draft and clear its number (needed, for example, to change the company/journal of a wrongly-loaded vendor bill), because the form blocks saving without the number.

## How

- View override: removes the form-level `required` on `l10n_latam_document_number` and `l10n_latam_document_type_id`. The fields are still enforced **at posting time** by the standard `l10n_latam_invoice_document` constraints (`_check_l10n_latam_documents`), so no data integrity is lost.
- Model constraint `_check_journal`: prevents changing the journal of a **posted** move that uses documents.

## Testing

Faithful backport of the 19.0 tests (`tests/test_patch_l10n_ar.py`), which patch `l10n_ar` `TestArManual.test_15/16` to assert the requirement is validated at posting instead of at form level. Verified locally on a fresh 18.0 DB (`l10n_ar` + full AR stack + demo):

```
l10n_ar:                        4 tests
l10n_latam_invoice_document_ux: 3 tests
0 failed, 0 error(s)
```