### PR TITLE
[IMP] account_background_post: schedule background posting and retry on error

### DIFF
--- a/account_background_post/README.rst
+++ b/account_background_post/README.rst
@@ -18,6 +18,10 @@ This module let the user to improve the use of the post entries action on the in
 
 1. Let the user to post the entries in Background. This new option on the wizard will mark the invoices to be validated so they can be validated in Background, if we found and error with one of them, we leave a message in the invoice notifying the internal users and unmark the invoice so the validate process can continue with other invoices.
 
+   1.1 The marked invoices can also carry a scheduling date ("Post in Background At", ``background_post_date``). The cron only posts them once that date is reached, so a caller can defer a posting to a known future moment (for example, the next invoice date of a subscription) instead of posting on the next run. Without a date the behaviour is the historical one: the invoice is posted on the next cron run.
+
+   1.2 Optionally, an invoice that fails can be retried instead of being unmarked on the first error. While there are retries left we reschedule the invoice (and count the attempt on ``background_post_attempts``); once they are exhausted we unmark it and leave the message in the invoice, as always. Retries are disabled by default, so the behaviour does not change unless they are configured.
+
 2. If the user want to validate the invoices at the current moment not in Background, we do the next two changes:
 
    2.1 We only let the user to validate small batch of invoices. By default only 20 invoices. If the user try to select more than 20 invoices then we force him to use Post in Background option.
@@ -38,7 +42,11 @@ Configuration
 
 To configure this module, you need to:
 
-#. Nothing to configure
+#. Nothing to configure, but the following system parameters are available:
+
+   * ``account_background_post.batch_size`` (default 20): how many invoices the user can validate synchronously before being forced to use the background option.
+   * ``account_background_post.max_retries`` (default 0): how many times the cron retries an invoice that failed before unmarking it and notifying the error. With 0 there are no retries.
+   * ``account_background_post.retry_delay_minutes`` (default 30): how long to wait before retrying an invoice that failed.
 
 Usage
 =====

--- a/account_background_post/i18n/account_background_post.pot
+++ b/account_background_post/i18n/account_background_post.pot
@@ -27,6 +27,12 @@ msgid "Background Post"
 msgstr ""
 
 #. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_attempts
+msgid "Background Post Attempts"
+msgstr ""
+
+#. module: account_background_post
 #: model:ir.actions.server,name:account_background_post.ir_cron_background_post_invoices_ir_actions_server
 msgid "Background Post Invoices: cron"
 msgstr ""
@@ -70,8 +76,22 @@ msgid "If True then this invoice will be validated in the background by cron."
 msgstr ""
 
 #. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_date
+msgid ""
+"If set, the background cron waits until this date to post this invoice. If "
+"empty, the invoice is posted on the next cron run."
+msgstr ""
+
+#. module: account_background_post
 #: model:ir.model,name:account_background_post.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_attempts
+msgid "Number of failed attempts to post this invoice in the background."
 msgstr ""
 
 #. module: account_background_post
@@ -82,6 +102,17 @@ msgstr ""
 #. module: account_background_post
 #: model_terms:ir.ui.view,arch_db:account_background_post.validate_account_move_view
 msgid "Post in Background"
+msgstr ""
+
+#. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_date
+msgid "Post in Background At"
+msgstr ""
+
+#. module: account_background_post
+#: model_terms:ir.ui.view,arch_db:account_background_post.view_move_form
+msgid "Scheduled for"
 msgstr ""
 
 #. module: account_background_post

--- a/account_background_post/i18n/es.po
+++ b/account_background_post/i18n/es.po
@@ -35,6 +35,12 @@ msgid "Background Post"
 msgstr "Validación en Background"
 
 #. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_attempts
+msgid "Background Post Attempts"
+msgstr "Intentos de Validación en Background"
+
+#. module: account_background_post
 #: model:ir.actions.server,name:account_background_post.ir_cron_background_post_invoices_ir_actions_server
 msgid "Background Post Invoices: cron"
 msgstr "Facturas Validación en Background: cron"
@@ -78,9 +84,26 @@ msgid "If True then this invoice will be validated in the background by cron."
 msgstr "Si es Verdadero esta factura sera validada en background por el cron."
 
 #. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_date
+msgid ""
+"If set, the background cron waits until this date to post this invoice. If "
+"empty, the invoice is posted on the next cron run."
+msgstr ""
+"Si se completa, el cron de background espera hasta esta fecha para validar "
+"esta factura. Si está vacía, la factura se valida en la próxima corrida del "
+"cron."
+
+#. module: account_background_post
 #: model:ir.model,name:account_background_post.model_account_move
 msgid "Journal Entry"
 msgstr "Asiento contable"
+
+#. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_attempts
+msgid "Number of failed attempts to post this invoice in the background."
+msgstr "Cantidad de intentos fallidos de validar esta factura en background."
 
 #. module: account_background_post
 #: model_terms:ir.ui.view,arch_db:account_background_post.validate_account_move_view
@@ -91,6 +114,17 @@ msgstr "Solo use esta opción para validar pequeños lotes de facturas"
 #: model_terms:ir.ui.view,arch_db:account_background_post.validate_account_move_view
 msgid "Post in Background"
 msgstr "Validar en Background"
+
+#. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_date
+msgid "Post in Background At"
+msgstr "Fecha de Validación en Background"
+
+#. module: account_background_post
+#: model_terms:ir.ui.view,arch_db:account_background_post.view_move_form
+msgid "Scheduled for"
+msgstr "Programada para"
 
 #. module: account_background_post
 #: model:ir.model.fields,help:account_background_post.field_validate_account_move__count_inv

--- a/account_background_post/models/account_move.py
+++ b/account_background_post/models/account_move.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from odoo import _, api, fields, models
 from odoo.tools import plaintext2html
@@ -12,6 +13,27 @@ class AccountMove(models.Model):
     background_post = fields.Boolean(
         help="If True then this invoice will be validated in the background by cron.", copy=False, tracking=True
     )
+    background_post_date = fields.Datetime(
+        string="Post in Background At",
+        help="If set, the background cron waits until this date to post this invoice. If empty, the invoice is "
+        "posted on the next cron run.",
+        copy=False,
+        tracking=True,
+        index="btree_not_null",
+    )
+    background_post_attempts = fields.Integer(
+        help="Number of failed attempts to post this invoice in the background.",
+        copy=False,
+        readonly=True,
+    )
+
+    @api.model
+    def _get_background_post_max_retries(self):
+        return int(self.env["ir.config_parameter"].sudo().get_param("account_background_post.max_retries", 0))
+
+    @api.model
+    def _get_background_post_retry_delay(self):
+        return int(self.env["ir.config_parameter"].sudo().get_param("account_background_post.retry_delay_minutes", 30))
 
     def get_internal_partners(self):
         res = self.env["res.partner"]
@@ -21,32 +43,80 @@ class AccountMove(models.Model):
         return res
 
     @api.model
+    def _get_background_post_due_moves(self):
+        # Las inmediatas primero: una tanda que falla y se reprograma no le tiene que comer el
+        # turno a las que están sanas.
+        domain = [("background_post", "=", True), ("state", "=", "draft")]
+        immediate = self.search(domain + [("background_post_date", "=", False)])
+        scheduled = self.search(
+            domain + [("background_post_date", "<=", fields.Datetime.now())],
+            order="background_post_date asc",
+        )
+        return immediate + scheduled
+
+    @api.model
     def _cron_background_post_invoices(self, ids=None):
         """Busca las facturas que estan marcadas por ser validadas en background y las valida."""
-        if ids is not None:
-            moves = self.browse(ids)
-        else:
-            moves = self.search([("background_post", "=", True), ("state", "=", "draft")])
+        moves = self.browse(ids) if ids is not None else self._get_background_post_due_moves()
 
         total_len = len(moves)
-        self.env["ir.cron"]._commit_progress(remaining=total_len)
-        for move in moves:
+        max_retries = self._get_background_post_max_retries()
+        remaining_time = self.env["ir.cron"]._commit_progress(remaining=total_len)
+        for index, move in enumerate(moves):
+            if remaining_time <= 0:
+                # Cortamos dejando `remaining` en el progreso: con eso el cron se reprograma.
+                _logger.info(
+                    "Background post cron ran out of time, %s invoices left for the next run",
+                    total_len - index,
+                )
+                break
             try:
                 move.action_post()
-                self.env["ir.cron"]._commit_progress(processed=1)
+                remaining_time = self.env["ir.cron"]._commit_progress(processed=1)
             except Exception as exp:
                 self.env.cr.rollback()
-                move.background_post = False
-                move.message_post(
-                    body=_("We tried to validate this invoice on the background but got this error")
-                    + ": \n\n"
-                    + plaintext2html(str(exp), "em"),
-                    partner_ids=move.get_internal_partners().ids,
-                    body_is_html=True,
-                )
-                _logger.error("Error while trying to post invoice %s in background: %s", move.name, exp)
-                # Commit after each failure to set false background_post and post the message
-                self.env.cr.commit()  # pylint: disable=invalid-commit
+                if move._reschedule_background_post():
+                    _logger.warning(
+                        "Error while trying to post invoice %s in background, retry %s of %s scheduled for %s: %s",
+                        move.name or move.id,
+                        move.background_post_attempts,
+                        max_retries,
+                        move.background_post_date,
+                        exp,
+                    )
+                else:
+                    move._unschedule_background_post()
+                    move.message_post(
+                        # plaintext2html devuelve Markup, así que el body ya es html sin pasar
+                        # body_is_html, que en 19 avisa por warning y en runbot tiñe el build
+                        body=_("We tried to validate this invoice on the background but got this error")
+                        + ": \n\n"
+                        + plaintext2html(str(exp), "em"),
+                        partner_ids=move.get_internal_partners().ids,
+                    )
+                    _logger.error("Error while trying to post invoice %s in background: %s", move.name, exp)
+                # Commit after each failure to keep the retry state and the message
+                remaining_time = self.env["ir.cron"]._commit_progress()
+
+    def _reschedule_background_post(self):
+        """Devuelve True si la factura quedó reprogramada y False si agotó los reintentos."""
+        self.ensure_one()
+        if self.background_post_attempts >= self._get_background_post_max_retries():
+            return False
+        self.write(
+            {
+                "background_post_attempts": self.background_post_attempts + 1,
+                "background_post_date": fields.Datetime.now()
+                + timedelta(minutes=self._get_background_post_retry_delay()),
+            }
+        )
+        return True
+
+    def _schedule_background_post(self, post_at=False):
+        self.write({"background_post": True, "background_post_date": post_at, "background_post_attempts": 0})
+
+    def _unschedule_background_post(self):
+        self.write({"background_post": False, "background_post_date": False, "background_post_attempts": 0})
 
     def _post(self, soft=True):
         """Difiere el posteo de documentos de venta (facturas y notas de crédito) a background,
@@ -54,13 +124,15 @@ class AccountMove(models.Model):
 
         Si el contexto trae `force_background_post`, saltea el `super()._post()` para facturas
         de cliente y notas de crédito/débito de venta (`out_invoice`, `out_refund`); el resto
-        de los moves postea normalmente."""
+        de los moves postea normalmente. El contexto puede traer una fecha en lugar de `True`
+        para diferir el posteo hasta ese momento."""
         to_defer = self.env["account.move"]
-        if self.env.context.get("force_background_post"):
+        force = self.env.context.get("force_background_post")
+        if force:
             to_defer = self.filtered(lambda m: m.move_type in ("out_invoice", "out_refund"))
-            to_defer.write({"background_post": True})
+            to_defer._schedule_background_post(False if force is True else fields.Datetime.to_datetime(force))
         posted = super(AccountMove, self - to_defer)._post(soft=soft)
-        posted.filtered("background_post").background_post = False
+        posted.filtered("background_post")._unschedule_background_post()
         return posted
 
     def _get_moves_requiring_confirmation(self):

--- a/account_background_post/tests/__init__.py
+++ b/account_background_post/tests/__init__.py
@@ -1,0 +1,5 @@
+from . import test_invariants
+from . import test_cron
+from . import test_cron_failure
+from . import test_marking
+from . import test_batch_size

--- a/account_background_post/tests/common.py
+++ b/account_background_post/tests/common.py
@@ -1,0 +1,95 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+
+from .invariants import BackgroundPostInvariants
+
+
+class BackgroundPostCommon(AccountTestInvoicingCommon, BackgroundPostInvariants):
+    """Configuración de los escenarios del circuito de background.
+
+    El entorno (plan de cuentas, diarios, impuestos) sale de la base vía la clase de account;
+    los usuarios, los parámetros y los documentos los crea el test.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # El interno es el usuario con el que corre la suite: es interno por construcción y no
+        # depende de crear usuarios, que Odoo 19 deja inactivos si se los crea así.
+        cls.internal_partner = cls.env.user.partner_id
+        # El externo es un usuario de portal (share=True), como el cliente de una factura real.
+        cls.portal_user = cls.env["res.users"].create(
+            {
+                "name": "background_post_customer",
+                "login": "background_post_customer",
+                "company_id": cls.env.company.id,
+                "company_ids": [Command.set(cls.env.company.ids)],
+                "group_ids": [Command.set([cls.env.ref("base.group_portal").id])],
+            }
+        )
+        cls.external_partner = cls.portal_user.partner_id
+
+    def _create_bg_invoice(self, **kwargs):
+        kwargs.setdefault("price_unit", 100.0)
+        kwargs.setdefault("tax_ids", [])
+        return self._create_invoice_one_line(**kwargs)
+
+    def _set_param(self, key, value):
+        self.env["ir.config_parameter"].sudo().set_param("account_background_post.%s" % key, value)
+
+    def _open_validate_wizard(self, moves):
+        return (
+            self.env["validate.account.move"].with_context(active_model="account.move", active_ids=moves.ids).create({})
+        )
+
+    @contextmanager
+    def _neutralized_cursor(self, tolerate_rollback=False):
+        """El cron commitea después de cada factura y hace rollback ante un error; el cursor de
+        test prohíbe las dos cosas."""
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(self.env.cr, "commit", self.env.flush_all))
+            if tolerate_rollback:
+                stack.enter_context(patch.object(self.env.cr, "rollback", lambda: None))
+            yield
+
+    @contextmanager
+    def _failing_post(self, moves, error="ARCA no responde"):
+        """Hace fallar action_post solo en esas facturas, antes de que toquen nada."""
+        model = self.env["account.move"].__class__
+        original = model.action_post
+        broken_ids = set(moves.ids)
+
+        def action_post(self):
+            if broken_ids & set(self.ids):
+                raise UserError(error)
+            return original(self)
+
+        with patch.object(model, "action_post", action_post):
+            yield
+
+    def _add_followers(self, move, partners):
+        # Directo sobre mail.followers: message_subscribe depende de los subtipos por defecto del
+        # modelo y en account.move deja afuera al partner interno.
+        self.env["mail.followers"].sudo().create(
+            [{"res_model": move._name, "res_id": move.id, "partner_id": partner.id} for partner in partners]
+        )
+
+    def _run_cron(self, moves, tolerate_rollback=False):
+        """Corre el cron y verifica la batería de invariantes sobre lo que tocó.
+
+        Con sudo porque el ir.cron corre como root: con el usuario de la suite, el circuito no
+        ve los usuarios internos y el escenario dejaría de parecerse a producción."""
+        with self._neutralized_cursor(tolerate_rollback=tolerate_rollback):
+            self.env["account.move"].sudo()._cron_background_post_invoices()
+        self.assert_background_post_invariants(moves)
+
+    def _background_post_messages(self, move):
+        return move.sudo().message_ids.filtered(lambda m: "background" in (m.body or ""))

--- a/account_background_post/tests/invariants.py
+++ b/account_background_post/tests/invariants.py
@@ -1,0 +1,52 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+
+class BackgroundPostInvariants:
+    """Batería de invariantes del circuito de validación en background.
+
+    Valen después de cualquier operación del circuito — no son el assert específico de ningún
+    escenario. Los módulos que dependen de account_background_post heredan esta clase para
+    correrlas en sus propias suites.
+
+    Sin interruptores: un escenario que viole legítimamente una invariante lo declara en el
+    test, a la vista y con el motivo al lado.
+    """
+
+    def assert_background_post_invariants(self, moves):
+        self.assert_no_background_state_on_posted(moves)
+        self.assert_attempts_are_scheduled(moves)
+        self.assert_attempts_within_limit(moves)
+        self.assert_internal_recipients_are_internal(moves)
+
+    def assert_no_background_state_on_posted(self, moves):
+        # Una factura que salió del borrador no puede conservar estado de background.
+        for move in moves.filtered(lambda m: m.state != "draft"):
+            self.assertFalse(move.background_post, "%s ya no está en borrador y sigue marcada" % move.id)
+            self.assertFalse(move.background_post_date, "%s ya no está en borrador y conserva la fecha" % move.id)
+            self.assertEqual(move.background_post_attempts, 0, "%s conserva intentos ya validada" % move.id)
+
+    def assert_attempts_are_scheduled(self, moves):
+        # Un contador de intentos vivo siempre tiene marca y fecha: sin fecha el cron la
+        # reintentaría en cada corrida, sin esperar el delay.
+        for move in moves.filtered("background_post_attempts"):
+            self.assertTrue(move.background_post, "%s acumula intentos y no está marcada" % move.id)
+            self.assertTrue(move.background_post_date, "%s acumula intentos y no tiene fecha" % move.id)
+
+    def assert_attempts_within_limit(self, moves):
+        # Los intentos nunca pasan el tope configurado.
+        max_retries = self.env["account.move"]._get_background_post_max_retries()
+        for move in moves:
+            self.assertLessEqual(move.background_post_attempts, max_retries, "%s pasó el tope de reintentos" % move.id)
+
+    def assert_internal_recipients_are_internal(self, moves):
+        # El chatter de una factura tiene al cliente entre sus seguidores: si el filtro de
+        # destinatarios se afloja, el aviso de un error interno se le manda al cliente.
+        for partner in moves.sudo().get_internal_partners():
+            self.assertTrue(partner.user_ids, "%s no tiene usuario y quedó como destinatario" % partner.id)
+            self.assertFalse(
+                any(user.share for user in partner.user_ids),
+                "%s es externo y quedó como destinatario del aviso" % partner.id,
+            )

--- a/account_background_post/tests/test_batch_size.py
+++ b/account_background_post/tests/test_batch_size.py
@@ -1,0 +1,33 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import BackgroundPostCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBackgroundPostBatchSize(BackgroundPostCommon):
+    def test_batch_size_guard(self):
+        """Comportamientos 2 y 3 del relevamiento: un lote más grande que el tope obliga a usar
+        background — control positivo: si el bloqueo se pierde, el usuario vuelve a colgar la
+        sesión validando de más."""
+        invoices = self._create_bg_invoice() + self._create_bg_invoice()
+
+        with self.subTest("un lote más grande que el tope se bloquea"):
+            self._set_param("batch_size", "1")
+            wizard = self._open_validate_wizard(invoices)
+            # el cursor neutralizado deja que el rojo caiga en el bloqueo y no en el commit
+            with self._neutralized_cursor(), self.assertRaises(UserError):
+                wizard.validate_move()
+            self.assertEqual(set(invoices.mapped("state")), {"draft"})
+
+        with self.subTest("un lote dentro del tope se valida de a una"):
+            self._set_param("batch_size", "5")
+            wizard = self._open_validate_wizard(invoices)
+            with self._neutralized_cursor():
+                wizard.validate_move()
+            self.assertEqual(set(invoices.mapped("state")), {"posted"})
+            self.assert_background_post_invariants(invoices)

--- a/account_background_post/tests/test_cron.py
+++ b/account_background_post/tests/test_cron.py
@@ -1,0 +1,67 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import tagged
+
+from .common import BackgroundPostCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBackgroundPostCron(BackgroundPostCommon):
+    def test_cron_respects_the_schedule(self):
+        """Comportamientos 4, 5, 6 y 11 del relevamiento: qué hace el cron con la fecha
+        programada, y qué queda cuando la factura se valida a mano."""
+        invoice = self._create_bg_invoice()
+
+        with self.subTest("sin fecha, se valida en la próxima corrida"):
+            invoice._schedule_background_post()
+            self._run_cron(invoice)
+            self.assertEqual(invoice.state, "posted")
+
+        with self.subTest("con fecha futura, espera"):
+            scheduled = self._create_bg_invoice()
+            scheduled._schedule_background_post(fields.Datetime.now() + timedelta(hours=1))
+            self._run_cron(scheduled)
+            self.assertEqual(scheduled.state, "draft")
+            self.assertTrue(scheduled.background_post_date)
+
+        with self.subTest("una vez vencida la fecha, se valida"):
+            scheduled.background_post_date = fields.Datetime.now() - timedelta(minutes=1)
+            self._run_cron(scheduled)
+            self.assertEqual(scheduled.state, "posted")
+
+        with self.subTest("validarla a mano saca la programación"):
+            manual = self._create_bg_invoice()
+            manual._schedule_background_post(fields.Datetime.now() + timedelta(days=1))
+            manual.action_post()
+            self.assertEqual(manual.state, "posted")
+            self.assert_background_post_invariants(manual)
+
+    def test_healthy_invoices_are_posted_before_the_rescheduled_ones(self):
+        """Comportamiento 9: las facturas sin fecha van primero, y las programadas de la más
+        vieja a la más nueva, para que una tanda que falla no le coma el turno a las sanas."""
+        older = self._create_bg_invoice()
+        newer = self._create_bg_invoice()
+        healthy = self._create_bg_invoice()
+        older._schedule_background_post(fields.Datetime.now() - timedelta(hours=2))
+        newer._schedule_background_post(fields.Datetime.now() - timedelta(hours=1))
+        healthy._schedule_background_post()
+
+        # el orden observable es el orden en que el cron las valida
+        posted_order = []
+        model = self.env["account.move"].__class__
+        original = model.action_post
+
+        def action_post(this):
+            posted_order.extend(this.ids)
+            return original(this)
+
+        with patch.object(model, "action_post", action_post):
+            self._run_cron(healthy + older + newer)
+
+        self.assertEqual(posted_order, (healthy + older + newer).ids)

--- a/account_background_post/tests/test_cron_failure.py
+++ b/account_background_post/tests/test_cron_failure.py
@@ -1,0 +1,54 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from .common import BackgroundPostCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBackgroundPostFailure(BackgroundPostCommon):
+    @mute_logger("odoo.addons.account_background_post.models.account_move")
+    def test_failure_notifies_internals_and_retries(self):
+        """Comportamientos 7, 8 y 10 del relevamiento: qué pasa cuando la validación falla, a
+        quién se le avisa, y que una factura rota no frene a las sanas."""
+        self._set_param("max_retries", "0")
+        self._set_param("retry_delay_minutes", "0")
+        broken = self._create_bg_invoice()
+        healthy = self._create_bg_invoice()
+        # el cliente es seguidor de la factura, como en cualquier factura real
+        self._add_followers(broken, self.internal_partner + self.external_partner)
+
+        with self.subTest("sin reintentos, la primera falla la desmarca y avisa solo a internos"):
+            (broken + healthy)._schedule_background_post()
+            with self._failing_post(broken):
+                self._run_cron(broken + healthy, tolerate_rollback=True)
+            self.assertEqual(broken.state, "draft")
+            self.assertFalse(broken.background_post)
+            self.assertEqual(broken.background_post_attempts, 0)
+            messages = self._background_post_messages(broken)
+            self.assertEqual(len(messages), 1, "el aviso al desmarcar tiene que ser uno solo")
+            self.assertEqual(messages.partner_ids, self.internal_partner)
+            self.assertEqual(healthy.state, "posted", "una factura rota no puede frenar a las sanas")
+
+        self._set_param("max_retries", "2")
+        retried = self._create_bg_invoice()
+        retried._schedule_background_post()
+
+        with self.subTest("con reintentos disponibles, reprograma y no avisa"):
+            for attempt in (1, 2):
+                with self._failing_post(retried):
+                    self._run_cron(retried, tolerate_rollback=True)
+                self.assertTrue(retried.background_post)
+                self.assertEqual(retried.background_post_attempts, attempt)
+                self.assertFalse(self._background_post_messages(retried))
+
+        with self.subTest("agotados los reintentos, la desmarca y avisa una sola vez"):
+            with self._failing_post(retried):
+                self._run_cron(retried, tolerate_rollback=True)
+            self.assertFalse(retried.background_post)
+            self.assertFalse(retried.background_post_date)
+            self.assertEqual(retried.background_post_attempts, 0)
+            self.assertEqual(len(self._background_post_messages(retried)), 1)

--- a/account_background_post/tests/test_invariants.py
+++ b/account_background_post/tests/test_invariants.py
@@ -1,0 +1,74 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import tagged
+
+from .common import BackgroundPostCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBackgroundPostInvariants(BackgroundPostCommon):
+    """Cada invariante de la batería, en los dos sentidos: que no moleste con una operación
+    sana, y que detecte el estado defectuoso para el que existe."""
+
+    def test_no_background_state_on_posted(self):
+        invoice = self._create_bg_invoice()
+        invoice._schedule_background_post()
+        # operación sana: el cron la valida y limpia el estado
+        self._run_cron(invoice)
+        self.assert_no_background_state_on_posted(invoice)
+
+        # defectuosa: validada y todavía marcada
+        invoice.background_post = True
+        with self.assertRaises(AssertionError):
+            self.assert_no_background_state_on_posted(invoice)
+
+    def test_attempts_are_scheduled(self):
+        self._set_param("max_retries", "2")
+        invoice = self._create_bg_invoice()
+        invoice._schedule_background_post()
+        # sana: reprogramar deja marca y fecha
+        invoice._reschedule_background_post()
+        self.assert_attempts_are_scheduled(invoice)
+
+        # defectuosa: contador vivo sin fecha, que el cron reintentaría en cada corrida
+        invoice.background_post_date = False
+        with self.assertRaises(AssertionError):
+            self.assert_attempts_are_scheduled(invoice)
+
+    def test_attempts_within_limit(self):
+        self._set_param("max_retries", "1")
+        invoice = self._create_bg_invoice()
+        invoice._schedule_background_post()
+        # sana: un reintento con tope 1
+        invoice._reschedule_background_post()
+        self.assert_attempts_within_limit(invoice)
+
+        # defectuosa: más intentos que el tope
+        invoice.background_post_attempts = 5
+        with self.assertRaises(AssertionError):
+            self.assert_attempts_within_limit(invoice)
+
+    def test_internal_recipients_are_internal(self):
+        invoice = self._create_bg_invoice()
+        self._add_followers(invoice, self.internal_partner + self.external_partner)
+        # sana: el filtro deja afuera al cliente
+        self.assert_internal_recipients_are_internal(invoice)
+        self.assertEqual(invoice.sudo().get_internal_partners(), self.internal_partner)
+
+        # defectuosa: el filtro aflojado devuelve a todos los seguidores
+        model = self.env["account.move"].__class__
+        with patch.object(model, "get_internal_partners", lambda self: self.message_partner_ids):
+            with self.assertRaises(AssertionError):
+                self.assert_internal_recipients_are_internal(invoice)
+
+    def test_battery_runs_after_a_scheduled_posting(self):
+        # La batería completa sobre el camino normal: no molesta a una operación sana.
+        invoice = self._create_bg_invoice()
+        invoice._schedule_background_post(fields.Datetime.now())
+        self._run_cron(invoice)
+        self.assertEqual(invoice.state, "posted")

--- a/account_background_post/tests/test_marking.py
+++ b/account_background_post/tests/test_marking.py
@@ -1,0 +1,60 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from datetime import timedelta
+
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from .common import BackgroundPostCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBackgroundPostMarking(BackgroundPostCommon):
+    def test_wizard_marks_only_the_drafts(self):
+        """Comportamientos 1 y 13 del relevamiento: el wizard marca los borradores de la
+        selección y no toca lo que ya está validado."""
+        draft = self._create_bg_invoice()
+        posted = self._create_bg_invoice()
+        posted.action_post()
+        # con fecha vieja puesta, para verificar que marcar de nuevo empieza de cero
+        draft.background_post_date = fields.Datetime.now() + timedelta(days=7)
+
+        wizard = self.env["validate.account.move"].create({"move_ids": [Command.set((draft + posted).ids)]})
+        wizard.action_background_post()
+
+        self.assertTrue(draft.background_post)
+        self.assertFalse(draft.background_post_date, "marcar desde el wizard es validar en la próxima corrida")
+        self.assertFalse(posted.background_post)
+        self.assert_background_post_invariants(draft + posted)
+
+    def test_context_defers_only_sale_documents(self):
+        """Comportamiento 12 del relevamiento y acceptance criteria de la spec de ecommerce:
+        el contexto difiere facturas y notas de crédito de cliente; el resto valida normal."""
+        for move_type, deferred in (("out_invoice", True), ("out_refund", True), ("in_invoice", False)):
+            with self.subTest(move_type=move_type):
+                move = self._create_bg_invoice(move_type=move_type)
+                move.with_context(force_background_post=True).action_post()
+                self.assertEqual(move.background_post, deferred)
+                self.assertEqual(move.state, "draft" if deferred else "posted")
+                self.assert_background_post_invariants(move)
+
+    def test_context_accepts_a_posting_date(self):
+        """Comportamiento 12: el contexto puede traer la fecha en la que hay que validar."""
+        move = self._create_bg_invoice()
+        post_at = fields.Datetime.now() + timedelta(days=1)
+        move.with_context(force_background_post=post_at).action_post()
+        self.assertEqual(move.state, "draft")
+        self.assertEqual(move.background_post_date, post_at)
+
+    def test_context_true_clears_a_stale_date(self):
+        """Comportamiento 12: True significa "en la próxima corrida", así que no puede heredar
+        una fecha de una programación anterior."""
+        move = self._create_bg_invoice()
+        # la fecha vieja se pone a mano: armarla con _schedule_background_post haría que el test
+        # dependa del mismo método que verifica, y pasaría en verde con el reset roto
+        move.write({"background_post": True, "background_post_date": fields.Datetime.now() + timedelta(days=7)})
+        move.with_context(force_background_post=True).action_post()
+        self.assertTrue(move.background_post)
+        self.assertFalse(move.background_post_date)

--- a/account_background_post/views/account_move_views.xml
+++ b/account_background_post/views/account_move_views.xml
@@ -34,6 +34,7 @@
                     <div class="alert alert-info text-center" role="alert" invisible="not background_post">
                         <strong>⚠️ This invoice is pending validation in background</strong>
                         <p class="mb-0">This invoice will be automatically validated by the background process. If you validate it manually, the background flag will be automatically removed.</p>
+                        <p class="mb-0" invisible="not background_post_date">Scheduled for<field name="background_post_date" readonly="1" class="oe_inline ms-1"/></p>
                     </div>
                 </xpath>
             </field>

--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -27,7 +27,7 @@ class ValidateAccountMove(models.TransientModel):
         return res
 
     def action_background_post(self):
-        self.move_ids.filtered(lambda m: m.state == "draft").background_post = True
+        self.move_ids.filtered(lambda m: m.state == "draft")._schedule_background_post()
         self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
 
     def validate_move(self):


### PR DESCRIPTION
## What

`account_background_post` could only mean "post it on the next cron run": the `background_post` boolean was the whole scheduling API. This adds two fields **next to it** instead of replacing it:

- `background_post_date` (Datetime): the cron waits for this date before posting the invoice. Without a date the behaviour is the historical one, so the driving use case — deferring a posting to a known future moment, such as the next invoice date of a subscription — is available without changing what every database does today.
- `background_post_attempts` (Integer): the failed attempts of the retry loop.

Retries are opt-in. Until now the first failure unscheduled the invoice and notified the error, and that is still exactly what happens with the default configuration (`max_retries = 0`). Once retries are configured, the invoice is rescheduled while there are attempts left and is only unscheduled and notified when they run out.

## Changes

- `background_post` (Boolean) stays as the flag that puts an invoice in the background circuit. `background_post_date` (Datetime, `btree_not_null` index) and `background_post_attempts` (Integer) are added.
- `_get_background_post_due_moves()` returns the invoices the cron has to post now: the undated ones first, then the scheduled ones from the oldest date on. The cron also stops when the time budget returned by `_commit_progress` runs out, leaving `remaining` on the progress so it is rescheduled and resumes where it stopped. Both things keep a batch that keeps failing and rescheduling from eating the window of the invoices that would post fine.
- On failure, `_reschedule_background_post()` counts the attempt and reschedules `retry_delay_minutes` ahead while there are retries left; otherwise `_unschedule_background_post()` clears the three fields and the error is notified as before.
- `force_background_post` accepts a date on top of `True`. Scheduling goes through `_schedule_background_post()`, shared with the wizard, so it always starts from scratch: `True` means "on the next run" even if the invoice was carrying a date from a previous attempt.
- The form banner shows the scheduled datetime when there is one. The list decoration and the search filter are untouched: they keep working on the boolean.
- No migration script and no manifest bump — there is nothing to migrate, the two new fields are created by the module update.
- First tests of the module: a battery of invariants (`tests/invariants.py`) plus a suite grouped by mechanism. The battery lives here because this module is the top of its own Adhoc dependency chain, so `account_ux`, `website_sale_background_post` and `sale_order_type_automation` can inherit it.
- `message_post` no longer passes `body_is_html`: `plaintext2html` already returns `Markup`, and the flag makes mail log a warning, which runbot counts as an error.

## Why the boolean is kept

The previous version of this PR replaced `background_post` with the date and dropped the column in a post-migration. Keeping the boolean means:

- no data migration and no dropped column on the databases that are running today,
- callers keep working untouched (`default_background_post`, `filtered("background_post")`, the `sale_order_type` flag), so the three companion PRs are not needed any more,
- customer filters, favourites and automations on the field keep working.

The boolean is the one to drop on v20, once the date is the only entry point.

## New system parameters

| Parameter | Default | Purpose |
|---|---|---|
| `account_background_post.max_retries` | 0 | Retries after a failure. With 0 the invoice is given up on the first error, as before |
| `account_background_post.retry_delay_minutes` | 30 | How long to wait before retrying |

## Test plan

```
odoo-bin -d <db> -u account_background_post --test-enable --test-tags=/account_background_post
→ account_background_post: 23 tests 9.87s
→ 0 failed, 0 error(s) of 13 tests, no warnings
```

Run on a database installed with `--without-demo=all`: the environment (chart of accounts, journals) comes from the database, the scenario configuration and every document are created by the tests.

### Invariants — what holds after any operation of the circuit

| Invariant | What it guards |
|---|---|
| `assert_no_background_state_on_posted` | An invoice that left the draft state keeps no mark, date or attempts |
| `assert_attempts_are_scheduled` | A live attempt counter always keeps its mark and its date — without a date the cron would retry on every run |
| `assert_attempts_within_limit` | The attempts never pass the configured limit |
| `assert_internal_recipients_are_internal` | The recipients of the error notice are internal users, never the customer that follows the invoice |

Each invariant is tested in both senses: a healthy operation does not trip it, and the defective state it exists for does.

### Behaviours covered

| # | Behaviour | Test |
|---|---|---|
| 1, 13 | The wizard marks the drafts of the selection and leaves what is already posted alone | `test_wizard_marks_only_the_drafts` |
| 2, 3 | A batch over the limit is blocked; within the limit the invoices are posted one by one | `test_batch_size_guard` |
| 4, 5, 6, 11 | The cron posts an undated invoice, waits for a future date, posts a due one, and a manual posting clears the schedule | `test_cron_respects_the_schedule` |
| 7, 8, 10 | The failure unmarks and notifies internals only, the retries reschedule without notifying, and a broken invoice does not stop the healthy ones | `test_failure_notifies_internals_and_retries` |
| 9 | The undated invoices are posted before the rescheduled ones | `test_healthy_invoices_are_posted_before_the_rescheduled_ones` |
| 12 | The context defers sale documents and lets the rest post normally, with `True` and with a date | `test_context_*` |

### Demonstrated in red

Every test was demonstrated by breaking, one at a time, the rule it protects — and then restored.

| Break | Test that went red |
|---|---|
| `<=` → `>=` on the due date domain | `test_cron_respects_the_schedule` (and the invariant caught the leftover date) |
| `immediate + scheduled` → `scheduled + immediate` | `test_healthy_invoices_are_posted_before_the_rescheduled_ones` |
| `get_internal_partners()` → `message_partner_ids` | `test_failure_notifies_internals_and_retries` — the customer showed up among the recipients |
| The wizard's `state == "draft"` filter removed | `test_wizard_marks_only_the_drafts` |
| `move_type in (...)` → every move | `test_context_defers_only_sale_documents` |
| The context date ignored | `test_context_accepts_a_posting_date` |
| The date reset dropped from `_schedule_background_post` | `test_context_true_clears_a_stale_date` and `test_wizard_marks_only_the_drafts` |
| The batch size guard skipped | `test_batch_size_guard` |

The red pass found a weak test of its own: `test_context_true_clears_a_stale_date` built its stale date **through the method it was verifying**, so it passed with the reset broken. It now writes the date directly.

### Declared, not implemented

| Scenario | Why |
|---|---|
| The cron stopping when its time budget runs out | Outside a cron, `_commit_progress` returns infinity; forcing it means mocking `ir.cron` and the test would verify the mock |
| The transactional isolation of the failure path (rollback and commit per invoice) | The test cursor forbids both operations. With them neutralised the tests verify the retry decision, the notice and that the run continues — not the isolation |
| The confirmation wizard always opening | Trivial override (`return self`), no signal in a test |

## Note

#311 also touches `_cron_background_post_invoices` and extracts the error notification into a hook. This PR deliberately leaves the notification code and its message untouched, so the overlap between the two is textual (the `except` branch) and there is no method signature to reconcile. Whichever merges second rebases.

Task: https://www.adhoc.inc/odoo/project.task/72206
