### PR TITLE
[FIX] account_invoice_tax: keep the tax line of a fixed tax when its amount nets to zero

### DIFF
--- a/account_invoice_tax/models/account_tax.py
+++ b/account_invoice_tax/models/account_tax.py
@@ -5,6 +5,33 @@ class AccountTax(models.Model):
     _inherit = "account.tax"
 
     @api.model
+    def _prepare_base_line_tax_repartition_grouping_key(
+        self, base_line, base_line_grouping_key, tax_data, tax_rep_data
+    ):
+        """Never drop the tax line of a fixed tax on a vendor bill.
+
+        The core removes every tax line whose amount nets to zero, which happens
+        with a fixed tax set on a positive and a negative base line: the fixed
+        amount follows the sign of ``price_unit``, so both cancel each other.
+        The amount of those taxes is the one managed by this module, and
+        ``AccountMove._apply_tax_overrides`` applies it by writing on the tax
+        line.  Without a line there is nothing to write on, so the manual amount
+        is silently lost from the entry while the totals widget still shows it.
+        """
+        res = super()._prepare_base_line_tax_repartition_grouping_key(
+            base_line, base_line_grouping_key, tax_data, tax_rep_data
+        )
+        record = base_line.get("record")
+        if (
+            tax_data["tax"].amount_type == "fixed"
+            and isinstance(record, models.Model)
+            and record._name == "account.move.line"
+            and record.move_id.move_type in ("in_invoice", "in_refund", "in_receipt")
+        ):
+            res["__keep_zero_line"] = True
+        return res
+
+    @api.model
     def _get_tax_totals_summary(self, base_lines, currency, company, cash_rounding=None):
         res = super()._get_tax_totals_summary(base_lines, currency, company, cash_rounding=cash_rounding)
         # ``tax_context`` is injected by AccountMove._compute_tax_totals when

--- a/account_invoice_tax/tests/test_account_invoice_tax.py
+++ b/account_invoice_tax/tests/test_account_invoice_tax.py
@@ -128,6 +128,47 @@ class TestAccountInvoiceTax(TransactionCase):
         self.assertAlmostEqual(abs(self._tax_line(invoice, self.tax_percent).balance), 150.0)
         self.assertNotIn(str(self.tax_percent.id), invoice.tax_override_data or {})
 
+    def test_override_survives_fixed_tax_netting_to_zero(self):
+        """Percepción de importe fijo sobre una línea positiva y una negativa
+        que la cancelan: el core borra la línea de impuesto en cero y el
+        override quedaba huérfano, así que el asiento se registraba sin la
+        percepción mientras el widget de totales sí la mostraba (ticket 124374).
+        """
+        invoice = self._make_invoice(self.tax_fixed)
+        invoice.write(
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Bonificación 11 %",
+                            "quantity": 1.0,
+                            "price_unit": -110.0,
+                            "account_id": self._acct_expense.id,
+                            "tax_ids": [Command.set(self.tax_fixed.ids)],
+                        }
+                    )
+                ]
+            }
+        )
+        self._make_wizard(
+            invoice, [{"tax_id": self.tax_fixed.id, "amount": 155.2, "new_tax": False}]
+        ).action_update_tax()
+
+        tax_line = self._tax_line(invoice, self.tax_fixed)
+        self.assertTrue(tax_line, "The tax line was dropped, the override is lost")
+        self.assertAlmostEqual(abs(tax_line.balance), 155.2)
+        # El asiento tiene que coincidir con el total mostrado al usuario.
+        self.assertAlmostEqual(invoice.amount_untaxed, 890.0)
+        self.assertAlmostEqual(invoice.amount_total, 1045.2)
+        payment_term_line = invoice.line_ids.filtered(lambda l: l.display_type == "payment_term")
+        self.assertAlmostEqual(abs(payment_term_line.balance), 1045.2)
+
+        # Al confirmar, la deuda con el proveedor tiene que ser el total.
+        invoice.invoice_date = fields.Date.context_today(invoice)
+        invoice.action_post()
+        self.assertAlmostEqual(invoice.amount_total, 1045.2)
+        self.assertAlmostEqual(invoice.amount_residual, 1045.2)
+
 
 @tagged("post_install", "-at_install")
 class TestAccountInvoiceTaxWizard(TransactionCase):


### PR DESCRIPTION
Fixed-amount taxes on a vendor bill silently disappeared from the accounting entry when the computed amount netted to zero, while the tax totals widget kept showing them.

## Problem

The fixed tax amount follows the sign of `price_unit` (`_eval_tax_amount_fixed_amount`), so a bill with one positive and one negative base line carrying the same fixed tax computes `+1.00` and `-1.00`. The core then drops the tax line: `_prepare_tax_lines` removes tax lines having a zero amount unless the grouping key sets `__keep_zero_line`.

The amount of those taxes is the one this module manages, and `_apply_tax_overrides` applies it by *writing on the tax line*. With no line there is nothing to write on, so the amount stored in `tax_override_data` was orphaned: the entry was posted without the tax and the payment term line was short by that amount. Meanwhile `_compute_tax_totals` kept injecting the override into the widget, so the screen showed a total the entry did not have.

## Fix

`AccountTax._prepare_base_line_tax_repartition_grouping_key` returns `__keep_zero_line = True` for fixed taxes on vendor bills, so their tax line is never dropped and the amount always has a line to be written on.

Trade-off: a fixed tax netting to zero now leaves a `0.00` tax line on the bill instead of no line at all. That seems the right side to err on for a tax whose amount is managed by hand — and it is what the totals widget shows anyway.

## Test plan

New `test_override_survives_fixed_tax_netting_to_zero`: bill with a `+1000` line and a `-110` line, both with the fixed tax, set to `155.20` through the wizard. Asserts the tax line exists, that the totals and the payment term line match it, and that they still match after posting.

- without the fix: `1 failed` — `AssertionError: The tax line was dropped, the override is lost`
- with the fix: `0 failed, 0 error(s) of 6 tests` (the 5 pre-existing tests stay green)
- core tax suites with the module installed (`TestAccountTax`, `TestInvoiceTaxes`, `TestAccountTaxDetailsReport`, `TestAccountEarlyPaymentDiscount`, `TestAccountPaymentTerms`): 103 tests, the only error reproduces with the fix reverted (test DB has entries linked to the tax under test)

Internal ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124374
