### PR TITLE
[FIX] l10n_latam_invoice_document_ux: flag missing document number on confirm

### DIFF
--- a/l10n_latam_invoice_document_ux/__manifest__.py
+++ b/l10n_latam_invoice_document_ux/__manifest__.py
@@ -11,6 +11,11 @@
     "data": [
         "views/account_move_view.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "l10n_latam_invoice_document_ux/static/src/js/account_move_form.js",
+        ],
+    },
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/l10n_latam_invoice_document_ux/static/src/js/account_move_form.js
+++ b/l10n_latam_invoice_document_ux/static/src/js/account_move_form.js
@@ -1,0 +1,23 @@
+import { AccountMoveFormController } from "@account/components/account_move_form/account_move_form";
+import { patch } from "@web/core/utils/patch";
+
+patch(AccountMoveFormController.prototype, {
+    /**
+     * We clear the native `required` of the document number so drafts can be saved without it, which leaves
+     * the constraint as the only guard on confirm: a modal that does not point at the field. Here we require
+     * it on confirm instead, marking the field invalid and aborting the post.
+     */
+    async beforeExecuteActionButton(clickParams) {
+        const record = this.model.root;
+        if (
+            clickParams.name === "action_post" &&
+            record.data.l10n_latam_use_documents &&
+            record.data.l10n_latam_manual_document_number &&
+            !record.data.l10n_latam_document_number
+        ) {
+            await record.setInvalidField("l10n_latam_document_number");
+            return false;
+        }
+        return super.beforeExecuteActionButton(...arguments);
+    },
+});


### PR DESCRIPTION

Confirming a vendor bill without a document number raises a modal listing invoice ids and leaves the field unmarked, so the user cannot tell what is missing. The module clears the native `required` on purpose -drafts must be saveable without a number- so the constraint was the only guard.

The form controller now validates the number when the confirm button is pressed and marks the field invalid instead of opening the modal. Saving a draft without a number keeps working, and the constraint still guards posts that never go through the form.

Companion to ingadhoc/odoo-argentina#1546, same task.