### PR TITLE
[FIX] account_invoice_tax: keep zero-amount taxes coming from the inv…

### DIFF
--- a/account_invoice_tax/__manifest__.py
+++ b/account_invoice_tax/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Invoice Tax",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "author": "ADHOC SA",
     "category": "Localization",
     "depends": [

--- a/account_invoice_tax/tests/test_account_invoice_tax.py
+++ b/account_invoice_tax/tests/test_account_invoice_tax.py
@@ -19,6 +19,9 @@ class TestAccountInvoiceTax(TransactionCase):
         )
         cls.tax_fixed = cls._make_tax(cls, "Fixed Tax Test", "fixed", 1.0, acct_tax)
         cls.tax_percent = cls._make_tax(cls, "Percent Tax 21%", "percent", 21.0, acct_tax)
+        # Los impuestos "no gravado" / "exento" de la localización argentina son
+        # de importe fijo en cero, no porcentuales (verificado en base de cliente).
+        cls.tax_not_taxed = cls._make_tax(cls, "IVA No Gravado", "fixed", 0.0, acct_tax)
 
     def _make_tax(self, name, amount_type, amount, account):
         tax = self.env["account.tax"].create(
@@ -168,6 +171,56 @@ class TestAccountInvoiceTax(TransactionCase):
         invoice.action_post()
         self.assertAlmostEqual(invoice.amount_total, 1045.2)
         self.assertAlmostEqual(invoice.amount_residual, 1045.2)
+
+    def test_zero_amount_tax_is_kept_on_the_product_line(self):
+        """Factura con una línea al 21 % y otra con "IVA No Gravado" (impuesto
+        de importe fijo en cero): ajustar los centavos del IVA desde el wizard
+        borraba el No Gravado de su línea de producto.  Su línea de impuesto
+        existe aunque valga cero (``__keep_zero_line``), así que llega al wizard
+        con importe 0, se descartaba de ``tax_line_ids`` y quedaba fuera de
+        ``active_tax`` -- con lo cual el bloque de ``to_remove_tax`` lo
+        desvinculaba de todas las líneas de producto (ticket 126379).
+        """
+        invoice = self._make_invoice(self.tax_percent)
+        invoice.write(
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Concepto no gravado",
+                            "quantity": 1.0,
+                            "price_unit": 500.0,
+                            "account_id": self._acct_expense.id,
+                            "tax_ids": [Command.set(self.tax_not_taxed.ids)],
+                        }
+                    )
+                ]
+            }
+        )
+        not_taxed_line = invoice.invoice_line_ids.filtered(lambda l: l.price_unit == 500.0)
+
+        # El wizard se abre con las dos líneas: la de tasa 0 llega en 0, tal
+        # como la arma ``default_get``.
+        self._make_wizard(
+            invoice,
+            [
+                {"tax_id": self.tax_percent.id, "amount": 210.97, "new_tax": False},
+                {"tax_id": self.tax_not_taxed.id, "amount": 0.0, "new_tax": False},
+            ],
+        ).action_update_tax()
+
+        self.assertIn(
+            self.tax_not_taxed,
+            not_taxed_line.tax_ids,
+            "The zero-amount tax was unlinked from its product line",
+        )
+        self.assertTrue(
+            self._tax_line(invoice, self.tax_not_taxed),
+            "The zero-amount tax line was dropped from the entry",
+        )
+        self.assertAlmostEqual(abs(self._tax_line(invoice, self.tax_percent).balance), 210.97)
+        self.assertAlmostEqual(invoice.amount_untaxed, 1500.0)
+        self.assertAlmostEqual(invoice.amount_total, 1710.97)
 
 
 @tagged("post_install", "-at_install")

--- a/account_invoice_tax/wizards/account_invoice_tax.py
+++ b/account_invoice_tax/wizards/account_invoice_tax.py
@@ -33,7 +33,9 @@ class AccountInvoiceTax(models.TransientModel):
         return res
 
     def action_update_tax(self):
-        self.tax_line_ids.filtered(lambda l: not l.amount).unlink()
+        # Only the fixed taxes just added and left at zero: anything coming from
+        # the invoice must stay, or the block below unlinks it from every line.
+        self.tax_line_ids.filtered(lambda l: not l.amount and l.new_tax and l.tax_id.amount_type == "fixed").unlink()
         move = self.move_id
 
         active_tax = self.tax_line_ids.mapped("tax_id")


### PR DESCRIPTION
…oice

The wizard discarded every line left at zero before working out which taxes to remove.  A zero-amount tax that comes from the invoice -- "IVA No Gravado" is a fixed tax of amount 0, and its tax line survives thanks to __keep_zero_line -- therefore fell out of active_tax, landed in to_remove_tax and was unlinked from every product line: the bill silently lost the tax on the line that carried it.

Only discard the fixed taxes the user just added and left at zero, which was the point of dropping them in the first place.  Percentage taxes are recomputed by the tax engine, so a zero amount there is a legitimate result rather than a request to remove the tax.