### PR TITLE
[FIX] account_invoice_partial: timeout on invoices with many lines

### DIFF
--- a/account_invoice_partial/wizards/account_invoice_partial_wizard.py
+++ b/account_invoice_partial/wizards/account_invoice_partial_wizard.py
@@ -2,8 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import fields, models
-from odoo.tools import float_round
+from odoo import Command, _, fields, models
+from odoo.tools import float_round, formatLang
 
 
 class AccountInvoicePartialWizard(models.TransientModel):
@@ -30,10 +30,42 @@ class AccountInvoicePartialWizard(models.TransientModel):
         help="The tie-breaking rule used for float rounding operations",
     )
 
+    def _get_partial_line_vals(self, line):
+        """Values to write on ``line``. Hook for modules applying the percentage on another field."""
+        return {
+            "quantity": float_round(
+                line.quantity * (self.percentage_to_invoice / 100),
+                precision_rounding=self.rounding,
+                rounding_method=self.rounding_method,
+            ),
+        }
+
+    def _log_partial_invoice(self, amount_before):
+        """Log the change on the invoice chatter: the write runs with tracking disabled for performance."""
+        invoice = self.invoice_id
+        invoice._message_log(
+            body=_(
+                "Invoice percentage applied: %(percentage)s%%. Total changed from %(before)s to %(after)s.",
+                percentage=formatLang(self.env, self.percentage_to_invoice),
+                before=formatLang(self.env, amount_before, currency_obj=invoice.currency_id),
+                after=formatLang(self.env, invoice.amount_total, currency_obj=invoice.currency_id),
+            )
+        )
+
     def compute_new_quantity(self):
         self.ensure_one()
-        for line in self.invoice_id.invoice_line_ids.with_context(check_move_validity=False):
-            quantity = line.quantity * (self.percentage_to_invoice / 100)
-            line.quantity = float_round(
-                quantity, precision_rounding=self.rounding, rounding_method=self.rounding_method
-            )
+        # One write on the move instead of one assignment per line. Line by line, each assignment is a write
+        # that runs the whole dynamic lines sync (taxes, payment terms, discount allocation), and every nested
+        # write calls fields_get() in the tracking block of account.move.line.write() -- which, with no tracked
+        # field in vals, ends up describing every field of the model. tracking_disable skips that block.
+        invoice = self.invoice_id.with_context(check_move_validity=False, tracking_disable=True)
+        amount_before = invoice.amount_total
+        invoice.write(
+            {
+                "invoice_line_ids": [
+                    Command.update(line.id, self._get_partial_line_vals(line)) for line in invoice.invoice_line_ids
+                ],
+            }
+        )
+        # tracking_disable above means the amount change leaves no tracking values, so log it explicitly.
+        self._log_partial_invoice(amount_before)


### PR DESCRIPTION
Assigning `quantity` line by line turned every assignment into its own write on account.move.line, and each of those writes ran the whole dynamic lines sync of the move (taxes, payment terms, discount allocation).  That sync recomputes discount_allocation_needed, which assigns on every line of the move, and each of those assignments is yet another nested write.  Every nested write then called fields_get() in the tracking block of account.move.line.write(): `quantity` is not tracked, so tracking_fields came out empty, and fields_get([]) describes every field of the model instead of none -- and the result is thrown away anyway on a move that was never posted.

A profile of a 199-line invoice showed 556 s of wall clock, 443 s of them (80%) inside that fields_get, against 3 s of SQL.

- Write every line in a single write on the move with Command.update, so the dynamic lines sync runs once for the whole batch instead of once per line: it is guarded by _disable_recursion, so the nested line writes find the container already open and skip it.
- Pass tracking_disable to skip the tracking block, which is the escape hatch the core documents for this.
- Extract _get_partial_line_vals() so modules applying the percentage on another field can override the values and keep the batched write.

Change note: Facturar por porcentaje ya no queda cargando ni se corta en facturas con muchas líneas. Antes, en una factura de unas 200 líneas el sistema podía tardar varios minutos y terminar mostrando un error de conexión sin haber aplicado el porcentaje. Ahora el ajuste se aplica de una sola vez, desde el mismo botón "Invoice Percentage" de la factura y con el mismo resultado en las cantidades.