### PR TITLE
[IMP] account_background_post: schedule background posting and retry on error

### DIFF
--- a/account_background_post/README.rst
+++ b/account_background_post/README.rst
@@ -18,6 +18,10 @@ This module let the user to improve the use of the post entries action on the in
 
 1. Let the user to post the entries in Background. This new option on the wizard will mark the invoices to be validated so they can be validated in Background, if we found and error with one of them, we leave a message in the invoice notifying the internal users and unmark the invoice so the validate process can continue with other invoices.
 
+   1.1 The marked invoices can also carry a scheduling date ("Post in Background At", ``background_post_date``). The cron only posts them once that date is reached, so a caller can defer a posting to a known future moment (for example, the next invoice date of a subscription) instead of posting on the next run. Without a date the behaviour is the historical one: the invoice is posted on the next cron run.
+
+   1.2 Optionally, an invoice that fails can be retried instead of being unmarked on the first error. While there are retries left we reschedule the invoice (and count the attempt on ``background_post_attempts``); once they are exhausted we unmark it and leave the message in the invoice, as always. Retries are disabled by default, so the behaviour does not change unless they are configured.
+
 2. If the user want to validate the invoices at the current moment not in Background, we do the next two changes:
 
    2.1 We only let the user to validate small batch of invoices. By default only 20 invoices. If the user try to select more than 20 invoices then we force him to use Post in Background option.
@@ -38,7 +42,11 @@ Configuration
 
 To configure this module, you need to:
 
-#. Nothing to configure
+#. Nothing to configure, but the following system parameters are available:
+
+   * ``account_background_post.batch_size`` (default 20): how many invoices the user can validate synchronously before being forced to use the background option.
+   * ``account_background_post.max_retries`` (default 0): how many times the cron retries an invoice that failed before unmarking it and notifying the error. With 0 there are no retries.
+   * ``account_background_post.retry_delay_minutes`` (default 30): how long to wait before retrying an invoice that failed.
 
 Usage
 =====

--- a/account_background_post/i18n/account_background_post.pot
+++ b/account_background_post/i18n/account_background_post.pot
@@ -23,6 +23,12 @@ msgid "Background Post"
 msgstr ""
 
 #. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_attempts
+msgid "Background Post Attempts"
+msgstr ""
+
+#. module: account_background_post
 #: model:ir.actions.server,name:account_background_post.ir_cron_background_post_invoices_ir_actions_server
 #: model:ir.cron,cron_name:account_background_post.ir_cron_background_post_invoices
 msgid "Background Post Invoices: cron"
@@ -51,8 +57,22 @@ msgid "If True then this invoice will be validated in the background by cron."
 msgstr ""
 
 #. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_date
+msgid ""
+"If set, the background cron waits until this date to post this invoice. If "
+"empty, the invoice is posted on the next cron run."
+msgstr ""
+
+#. module: account_background_post
 #: model:ir.model,name:account_background_post.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_attempts
+msgid "Number of failed attempts to post this invoice in the background."
 msgstr ""
 
 #. module: account_background_post
@@ -75,6 +95,12 @@ msgstr ""
 #. module: account_background_post
 #: model_terms:ir.ui.view,arch_db:account_background_post.validate_account_move_view
 msgid "Post in Background"
+msgstr ""
+
+#. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_date
+msgid "Post in Background At"
 msgstr ""
 
 #. module: account_background_post

--- a/account_background_post/i18n/es.po
+++ b/account_background_post/i18n/es.po
@@ -26,6 +26,12 @@ msgid "Background Post"
 msgstr "Validación en Background"
 
 #. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_attempts
+msgid "Background Post Attempts"
+msgstr "Intentos de Validación en Background"
+
+#. module: account_background_post
 #: model:ir.actions.server,name:account_background_post.ir_cron_background_post_invoices_ir_actions_server
 msgid "Background Post Invoices: cron"
 msgstr "Facturas Validación en Background: cron"
@@ -52,9 +58,26 @@ msgid "If True then this invoice will be validated in the background by cron."
 msgstr "Si es Verdadero esta factura sera validada en background por el cron."
 
 #. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_date
+msgid ""
+"If set, the background cron waits until this date to post this invoice. If "
+"empty, the invoice is posted on the next cron run."
+msgstr ""
+"Si se completa, el cron de background espera hasta esta fecha para validar "
+"esta factura. Si está vacía, la factura se valida en la próxima corrida del "
+"cron."
+
+#. module: account_background_post
 #: model:ir.model,name:account_background_post.model_account_move
 msgid "Journal Entry"
 msgstr "Asiento contable"
+
+#. module: account_background_post
+#: model:ir.model.fields,help:account_background_post.field_account_bank_statement_line__background_post_attempts
+#: model:ir.model.fields,help:account_background_post.field_account_move__background_post_attempts
+msgid "Number of failed attempts to post this invoice in the background."
+msgstr "Cantidad de intentos fallidos de validar esta factura en background."
 
 #. module: account_background_post
 #: model:ir.model.fields,field_description:account_background_post.field_validate_account_move__move_ids
@@ -70,6 +93,12 @@ msgstr "Solo use esta opción para validar pequeños lotes de facturas"
 #: model_terms:ir.ui.view,arch_db:account_background_post.validate_account_move_view
 msgid "Post in Background"
 msgstr "Validar en Background"
+
+#. module: account_background_post
+#: model:ir.model.fields,field_description:account_background_post.field_account_bank_statement_line__background_post_date
+#: model:ir.model.fields,field_description:account_background_post.field_account_move__background_post_date
+msgid "Post in Background At"
+msgstr "Fecha de Validación en Background"
 
 #. module: account_background_post
 #: model:ir.model.fields,help:account_background_post.field_validate_account_move__count_inv

--- a/account_background_post/models/account_move.py
+++ b/account_background_post/models/account_move.py
@@ -1,5 +1,10 @@
+import logging
+from datetime import timedelta
+
 from odoo import _, api, fields, models
 from odoo.tools import plaintext2html
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -8,6 +13,27 @@ class AccountMove(models.Model):
     background_post = fields.Boolean(
         help="If True then this invoice will be validated in the background by cron.", copy=False, tracking=True
     )
+    background_post_date = fields.Datetime(
+        string="Post in Background At",
+        help="If set, the background cron waits until this date to post this invoice. If empty, the invoice is "
+        "posted on the next cron run.",
+        copy=False,
+        tracking=True,
+        index="btree_not_null",
+    )
+    background_post_attempts = fields.Integer(
+        help="Number of failed attempts to post this invoice in the background.",
+        copy=False,
+        readonly=True,
+    )
+
+    @api.model
+    def _get_background_post_max_retries(self):
+        return int(self.env["ir.config_parameter"].sudo().get_param("account_background_post.max_retries", 0))
+
+    @api.model
+    def _get_background_post_retry_delay(self):
+        return int(self.env["ir.config_parameter"].sudo().get_param("account_background_post.retry_delay_minutes", 30))
 
     def get_internal_partners(self):
         res = self.env["res.partner"]
@@ -15,6 +41,18 @@ class AccountMove(models.Model):
             if partner.user_ids and all(user._is_internal() for user in partner.user_ids):
                 res |= partner
         return res
+
+    @api.model
+    def _get_background_post_due_moves(self):
+        # Las inmediatas primero: una tanda que falla y se reprograma no le tiene que comer el
+        # turno a las que están sanas.
+        domain = [("background_post", "=", True), ("state", "=", "draft")]
+        immediate = self.search(domain + [("background_post_date", "=", False)])
+        scheduled = self.search(
+            domain + [("background_post_date", "<=", fields.Datetime.now())],
+            order="background_post_date asc",
+        )
+        return immediate + scheduled
 
     @api.model
     def _cron_background_post_invoices(self, batch_size=20, ids=None):
@@ -28,35 +66,81 @@ class AccountMove(models.Model):
             - ids: Si se pasa una lista de ids desde el ir_cron, solo se procesan esos registros.
         """
 
-        if ids is not None:
-            moves = self.browse(ids)
-        else:
-            moves = self.search([("background_post", "=", True), ("state", "=", "draft")])
+        moves = self.browse(ids) if ids is not None else self._get_background_post_due_moves()
 
+        max_retries = self._get_background_post_max_retries()
         for move in moves[:batch_size]:
             try:
                 move.action_post()
                 self.env.cr.commit()  # pragma pylint: disable=invalid-commit
             except Exception as exp:
                 self.env.cr.rollback()
-                move.background_post = False
-                move.message_post(
-                    body=_("We tried to validate this invoice on the background but got this error")
-                    + ": \n\n"
-                    + plaintext2html(str(exp), "em"),
-                    partner_ids=move.get_internal_partners().ids,
-                    body_is_html=True,
-                )
+                if move._reschedule_background_post():
+                    _logger.warning(
+                        "Error while trying to post invoice %s in background, retry %s of %s scheduled for %s: %s",
+                        move.name or move.id,
+                        move.background_post_attempts,
+                        max_retries,
+                        move.background_post_date,
+                        exp,
+                    )
+                else:
+                    move._unschedule_background_post()
+                    try:
+                        # the hook is overridable, don't let it abort the whole cron run
+                        move._notify_background_post_error(exp)
+                    except Exception:
+                        # the notification may have left the cursor aborted, keep at least the state
+                        self.env.cr.rollback()
+                        move._unschedule_background_post()
+                        _logger.exception("Could not notify the background post error of invoice %s", move.id)
+                    _logger.error("Error while trying to post invoice %s in background: %s", move.name or move.id, exp)
+                # Commiteamos tras cada fallo para conservar el estado del reintento y el mensaje
                 self.env.cr.commit()  # pragma pylint: disable=invalid-commit
         if len(moves) > batch_size:
             cron_id = self.env.context.get("cron_id")
             if cron_id:
                 # Si tenemos cron_id en el contexto, usamos ese para relanzar la ejecucion.
-                self.env["ir.cron"].browse(self.env.context["cron_id"])._trigger()
+                self.env["ir.cron"].browse(cron_id)._trigger()
                 return
             self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
 
+    def _reschedule_background_post(self):
+        """Devuelve True si la factura quedó reprogramada y False si agotó los reintentos."""
+        self.ensure_one()
+        if self.background_post_attempts >= self._get_background_post_max_retries():
+            return False
+        self.write(
+            {
+                "background_post_attempts": self.background_post_attempts + 1,
+                "background_post_date": fields.Datetime.now()
+                + timedelta(minutes=self._get_background_post_retry_delay()),
+            }
+        )
+        return True
+
+    def _schedule_background_post(self, post_at=False):
+        self.write({"background_post": True, "background_post_date": post_at, "background_post_attempts": 0})
+
+    def _unschedule_background_post(self):
+        self.write({"background_post": False, "background_post_date": False, "background_post_attempts": 0})
+
+    def _get_background_post_error_body(self, error):
+        return (
+            _("We tried to validate this invoice on the background but got this error")
+            + ": \n\n"
+            + plaintext2html(str(error), "em")
+        )
+
+    def _notify_background_post_error(self, error):
+        """Log the error on the invoice. Other modules may redirect it to the source document."""
+        self.ensure_one()
+        self.message_post(
+            body=self._get_background_post_error_body(error),
+            partner_ids=self.get_internal_partners().ids,
+        )
+
     def _post(self, soft=True):
         posted = super()._post(soft=soft)
-        posted.filtered("background_post").background_post = False
+        posted.filtered("background_post")._unschedule_background_post()
         return posted

--- a/account_background_post/wizards/validate_account_move.py
+++ b/account_background_post/wizards/validate_account_move.py
@@ -28,7 +28,7 @@ class ValidateAccountMove(models.TransientModel):
         return res
 
     def action_background_post(self):
-        self.move_ids.background_post = True
+        self.move_ids._schedule_background_post()
         self.env.ref("account_background_post.ir_cron_background_post_invoices")._trigger()
 
     def validate_move(self):


### PR DESCRIPTION
Backport to 18.0 of #312 (`account_background_post`), so the scheduling date and the retries are available on 18.0 databases as well.

## What it does

* `background_post_date` (Datetime, indexed): the cron waits until that date to post the invoice. Empty means the historical behaviour, post on the next run. It lets a caller defer a posting to a known future moment, such as the next invoice date of a subscription.
* `background_post_attempts` (Integer): failed attempts of the retry loop.
* `background_post` stays as the flag that puts an invoice in the circuit, so there is no data migration, no column drop, and `default_background_post` / `filtered("background_post")` / any existing filter or automation keeps working.
* `_get_background_post_due_moves()`: the undated ones first, then the scheduled ones from the oldest date on, so a batch that keeps failing and rescheduling does not eat the window of the invoices that would post fine.
* On error, `_reschedule_background_post()` counts the attempt and reschedules `retry_delay_minutes` later; once the retries are exhausted, `_unschedule_background_post()` clears the three fields and only then notifies. Retries default to 0, so a database that does not configure them gives up on the first error exactly as before.

New system parameters: `account_background_post.max_retries` (default 0) and `account_background_post.retry_delay_minutes` (default 30).

## Differences with the 19.0 change

All of them are 18.0 gaps, not design changes:

* The cron keeps the 18.0 `batch_size` argument and the re-trigger at the end of the batch. Odoo 18 has no `ir.cron._commit_progress`, so there is no time budget to stop on and the batch cut stays the guard it was.
* The error body and its posting are extracted to `_get_background_post_error_body` / `_notify_background_post_error`, which 19.0 already had from the notification hook. The message and its audience do not change; `body_is_html` is dropped because `plaintext2html` already returns `Markup` and the flag makes mail log a warning that runbot counts as an error.
* The form banner line ("Scheduled for") is not backported: 18.0 does not carry the background post alert on the invoice form, so there is nowhere to hang it. The scheduling date is still tracked on the chatter.
* `force_background_post` is not part of 18.0 either, so `_post` only clears the scheduling of what was posted manually.

No tests are added: they are not run on 18.0.

## Test plan

Checked on a fresh 18.0 database, `account_background_post` installed and updated clean, pre-commit green.

* An undated marked invoice is posted by the cron and the three fields are cleared.
* An invoice scheduled in the future is left in draft, marked and with its date; one scheduled in the past is posted.
* Posting manually an invoice that was scheduled clears mark, date and attempts.
* Order of the due invoices: undated first, then oldest scheduled first.
* With `max_retries=0`, a failing invoice goes back to draft unmarked with a single message on the invoice, addressed only to the internal followers (a portal follower is left out), and a healthy invoice in the same batch is still posted.
* With `max_retries=2`, the invoice is rescheduled on attempts 1 and 2 without any message, and is only unmarked and notified once when they are exhausted.
* The reschedule lands exactly `retry_delay_minutes` later (measured with 45).
* The wizard's "Post in Background" marks the invoices with no date and attempts at 0, and rescheduling with no date resets a previous date and attempt count.

`account_ux`, `website_sale_background_post` and `sale_order_type_automation` install clean on top of the patched module.

Task: https://www.adhoc.inc/odoo/project.task/72206
